### PR TITLE
Fix config checksum

### DIFF
--- a/templates/authenticate-deployment.yaml
+++ b/templates/authenticate-deployment.yaml
@@ -23,7 +23,8 @@ spec:
   template:
     metadata:
       annotations:
-        config/checksum: {{ print .Values.config.extraOpts | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}

--- a/templates/authenticate-deployment.yaml
+++ b/templates/authenticate-deployment.yaml
@@ -133,6 +133,8 @@ spec:
         configMap:
           name: {{ $configName }}
 {{- end }}
+      resources:
+{{ toYaml .Values.resources | indent 10 }}
 {{- if .Values.extraVolumes }}
       volumes:
 {{- toYaml .Values.extraVolumes | indent 8 }}

--- a/templates/authorize-deployment.yaml
+++ b/templates/authorize-deployment.yaml
@@ -12,7 +12,6 @@ metadata:
   name: {{ template "pomerium.authorize.fullname" . }}
 {{- if .Values.annotations }}
   annotations:
-    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ toYaml .Values.annotations | indent 4 }}
 {{- end }}
 spec:
@@ -24,7 +23,8 @@ spec:
   template:
     metadata:
       annotations:
-        config/checksum: {{ print .Values.config.extraOpts | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}

--- a/templates/authorize-deployment.yaml
+++ b/templates/authorize-deployment.yaml
@@ -105,6 +105,8 @@ spec:
         configMap:
           name: {{ $configName }}
 {{- end }}
+      resources:
+{{ toYaml .Values.resources | indent 10 }}
 {{- if .Values.extraVolumes }}
       volumes:
 {{- toYaml .Values.extraVolumes | indent 8 }}

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -116,6 +116,8 @@ spec:
         configMap:
           name: {{ $configName }}
 {{- end }}
+      resources:
+{{ toYaml .Values.resources | indent 10 }}
 {{- if .Values.extraVolumes }}
       volumes:
 {{- toYaml .Values.extraVolumes | indent 8 }}

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -12,7 +12,6 @@ metadata:
   name: {{ template "pomerium.proxy.fullname" . }}
 {{- if .Values.annotations }}
   annotations:
-    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ toYaml .Values.annotations | indent 4 }}
 {{- end }}
 spec:
@@ -24,7 +23,8 @@ spec:
   template:
     metadata:
       annotations:
-        config/checksum: {{ print .Values.config.extraOpts | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}


### PR DESCRIPTION
This definitively fix the way the checksum is done to force reload the pods on change:
- it was incorrectly applied to the deployment annotations
- it had an incorrect name
- it wasn't based on files

I also added the same for the secrets to be consistent.

I just wonder how all of this relates to hot-reloading:
- for sure for the secrets it is needed since they ends up in the pod as environment variables, so hot-reloading is not related
- but the config itself, if there is hot reloading maybe it is not needed to reload the pod?