### PR TITLE
Resources block must be at container level not pod

### DIFF
--- a/templates/authenticate-deployment.yaml
+++ b/templates/authenticate-deployment.yaml
@@ -128,6 +128,8 @@ spec:
             path: /ping
             port: https
             scheme: HTTPS
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
 {{- if or .Values.config.existingConfig .Values.config.policy }}
         volumeMounts:
         - mountPath: /etc/pomerium/
@@ -137,8 +139,6 @@ spec:
         configMap:
           name: {{ $configName }}
 {{- end }}
-      resources:
-{{ toYaml .Values.resources | indent 10 }}
 {{- if .Values.extraVolumes }}
       volumes:
 {{- toYaml .Values.extraVolumes | indent 8 }}

--- a/templates/authorize-deployment.yaml
+++ b/templates/authorize-deployment.yaml
@@ -100,6 +100,8 @@ spec:
             path: /ping
             port: https
             scheme: HTTPS
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
 {{- if or .Values.config.existingConfig .Values.config.policy }}
         volumeMounts:
         - mountPath: /etc/pomerium/
@@ -109,8 +111,6 @@ spec:
         configMap:
           name: {{ $configName }}
 {{- end }}
-      resources:
-{{ toYaml .Values.resources | indent 10 }}
 {{- if .Values.extraVolumes }}
       volumes:
 {{- toYaml .Values.extraVolumes | indent 8 }}

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -111,6 +111,8 @@ spec:
             path: /ping
             port: https
             scheme: HTTPS
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
 {{- if or .Values.config.existingConfig .Values.config.policy }}
         volumeMounts:
         - mountPath: /etc/pomerium/
@@ -120,8 +122,6 @@ spec:
         configMap:
           name: {{ $configName }}
 {{- end }}
-      resources:
-{{ toYaml .Values.resources | indent 10 }}
 {{- if .Values.extraVolumes }}
       volumes:
 {{- toYaml .Values.extraVolumes | indent 8 }}


### PR DESCRIPTION
The helm chart as of commit b09e4b7fce2be4838c1f5e5c16553bc3800b8a72 does not work because the resources block was added at the pod level instead of the container level where it belongs. Just moved these lines up a bit and indented `resources:` one level to make it part of the container spec rather than pod spec (the `indent 10` was actually already correct).

Such YAML, many Devops, wow!