### PR TITLE
Version bump to 0.2.1

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pomerium
-version: 1.3.0
-appVersion: 0.2.0
+version: 1.3.1
+appVersion: 0.2.1
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo.svg
 description: Pomerium is an identity-aware access proxy.

--- a/values.yaml
+++ b/values.yaml
@@ -115,7 +115,7 @@ extraVolumes: {}
 
 image:
   repository: "pomerium/pomerium"
-  tag: "v0.2.0"
+  tag: "v0.2.1"
   pullPolicy: "IfNotPresent"
 
 metrics:


### PR DESCRIPTION
Updates pomerium to latest 0.2 release.

Addresses CVE-2019-9512, CVE-2019-9514 and CVE-2019-14809.

