### PR TITLE
Fixes the annotations in deployments and services

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 4.2.0
+version: 4.2.1
 appVersion: 0.5.2
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo.svg

--- a/charts/pomerium/templates/authenticate-service.yaml
+++ b/charts/pomerium/templates/authenticate-service.yaml
@@ -11,15 +11,17 @@ metadata:
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
-annotations:
-{{- if .Values.authenticate.service.annotations }}
- {{- range $key, $value := .Values.authenticate.service.annotations }}
-   {{ $key }}: {{ $value | quote }}
- {{- end }}
-{{- else if .Values.service.annotations }}
- {{- range $key, $value := .Values.service.annotations }}
-   {{ $key }}: {{ $value | quote }}
- {{- end }}
+{{- if or .Values.authenticate.service.annotations .Values.service.annotations }}
+  annotations:
+  {{- if .Values.authenticate.service.annotations }}
+    {{- range $key, $value := .Values.authenticate.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- else if .Values.service.annotations }}
+    {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/pomerium/templates/authorize-deployment.yaml
+++ b/charts/pomerium/templates/authorize-deployment.yaml
@@ -10,15 +10,17 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: authorize
   name: {{ template "pomerium.authorize.fullname" . }}
+{{- if or .Values.authorize.deployment.annotations .Values.annotations }}
   annotations:
- {{- if .Values.authorize.deployment.annotations }}
- {{- range $key, $value := .Values.authorize.deployment.annotations }}
-   {{ $key }}: {{ $value | quote }}
- {{- end }}
-{{- else if .Values.annotations }}
- {{- range $key, $value := .Values.annotations }}
-   {{ $key }}: {{ $value | quote }}
- {{- end }}
+  {{- if .Values.authorize.deployment.annotations }}
+    {{- range $key, $value := .Values.authorize.deployment.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- else if .Values.annotations }}
+    {{- range $key, $value := .Values.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 spec:
   replicas: {{ default .Values.replicaCount .Values.authorize.replicaCount }}

--- a/charts/pomerium/templates/authorize-service.yaml
+++ b/charts/pomerium/templates/authorize-service.yaml
@@ -11,15 +11,17 @@ metadata:
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
-annotations:
-{{- if .Values.authorize.service.annotations }}
- {{- range $key, $value := .Values.authorize.service.annotations }}
-   {{ $key }}: {{ $value | quote }}
- {{- end }}
-{{- else if .Values.service.annotations }}
- {{- range $key, $value := .Values.service.annotations }}
-   {{ $key }}: {{ $value | quote }}
- {{- end }}
+{{- if or .Values.authorize.service.annotations .Values.service.annotations }}
+  annotations:
+  {{- if .Values.authorize.service.annotations }}
+    {{- range $key, $value := .Values.authorize.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- else if .Values.service.annotations }}
+    {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 spec:
 {{- if .Values.service.authorize.headless }}

--- a/charts/pomerium/templates/proxy-deployment.yaml
+++ b/charts/pomerium/templates/proxy-deployment.yaml
@@ -10,15 +10,17 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: proxy
   name: {{ template "pomerium.proxy.fullname" . }}
+{{- if or .Values.proxy.deployment.annotations .Values.annotations }}
   annotations:
- {{- if .Values.proxy.deployment.annotations }}
- {{- range $key, $value := .Values.proxy.deployment.annotations }}
-   {{ $key }}: {{ $value | quote }}
- {{- end }}
-{{- else if .Values.annotations }}
- {{- range $key, $value := .Values.annotations }}
-   {{ $key }}: {{ $value | quote }}
- {{- end }}
+  {{- if .Values.proxy.deployment.annotations }}
+    {{- range $key, $value := .Values.proxy.deployment.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- else if .Values.annotations }}
+    {{- range $key, $value := .Values.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 spec:
   replicas: {{ default .Values.replicaCount .Values.proxy.replicaCount }}

--- a/charts/pomerium/templates/proxy-service.yaml
+++ b/charts/pomerium/templates/proxy-service.yaml
@@ -11,15 +11,17 @@ metadata:
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
-annotations:
-{{- if .Values.proxy.service.annotations }}
- {{- range $key, $value := .Values.proxy.service.annotations }}
-   {{ $key }}: {{ $value | quote }}
- {{- end }}
-{{- else if .Values.service.annotations }}
- {{- range $key, $value := .Values.service.annotations }}
-   {{ $key }}: {{ $value | quote }}
- {{- end }}
+{{- if or .Values.proxy.service.annotations .Values.service.annotations }}
+  annotations:
+  {{- if .Values.proxy.service.annotations }}
+    {{- range $key, $value := .Values.proxy.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- else if .Values.service.annotations }}
+    {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}


### PR DESCRIPTION
Hi,

Sorry I missed it during the review of the previous PR on this, but there was two bugs with it:
- `annotations` was at the wrong level for services
- when `annotations` wasn't set in the values, a field without any value was generated which I think is illegal.