### PR TITLE
fix(helpers): invalid reference to existingCASecret

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 5.0.5
+version: 5.0.6
 appVersion: 0.6.2
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -229,7 +229,7 @@ Adapted from : https://github.com/helm/charts/blob/master/stable/drone/templates
 
 {{- define "pomerium.caSecret.name" -}}
 {{if .Values.config.existingCASecret }}
-{{- .Values.proxy.existingCASecret | trunc 63 | trimSuffix "-" -}}
+{{- .Values.config.existingCASecret | trunc 63 | trimSuffix "-" -}}
 {{- /* TODO in future: Remove legacy logic */ -}}
 {{- else if .Values.config.existingLegacyTLSSecret -}}
 {{- template "pomerium.fullname" . -}}


### PR DESCRIPTION
When providing an existing CA secret by `config.existingCASecret`, the template is incorrectly referencing `.Values.proxy.existingCASecret` to be used for `pomerium.caSecret.name` template.

error returned:
```
Error: template: pomerium/templates/_helpers.tpl:232:43: executing "pomerium.caSecret.name" at <63>: invalid value; expected string
helm.go:76: [debug] template: pomerium/templates/_helpers.tpl:232:43: executing "pomerium.caSecret.name" at <63>: invalid value; expected string
```
