### PR TITLE
Feature/store config in secret

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 7.0.1
+version: 8.0.0
 appVersion: 0.6.2
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -16,6 +16,7 @@
     - [Self Provisioned](#self-provisioned-1)
   - [Configuration](#configuration)
   - [Changelog](#changelog)
+    - [8.0.0](#800)
     - [7.0.0](#700)
     - [6.0.0](#600)
     - [5.0.0](#500)
@@ -23,6 +24,7 @@
     - [3.0.0](#300)
     - [2.0.0](#200)
   - [Upgrading](#upgrading)
+    - [8.0.0](#800-1)
     - [7.0.0](#700-1)
     - [5.0.0](#500-1)
     - [4.0.0](#400-1)
@@ -137,7 +139,6 @@ A full listing of Pomerium's configuration variables can be found on the [config
 | `config.rootDomain`                   | Root Domain specifies the sub-domain handled by pomerium. [See more](https://www.pomerium.io/docs/reference/reference.html#proxy-root-domains).                                                                                                                                                    | `corp.pomerium.io`                                                                    |
 | `config.administrators`               | Comma seperated list of email addresses of administrative users [See more](https://www.pomerium.io/configuration/#administrators).                                                                                                                                                                 | Optional                                                                              |
 | `config.existingSecret`               | Name of the existing Kubernetes Secret.                                                                                                                                                                                                                                                            |                                                                                       |
-| `config.existingConfig`               | Name of the existing Config Map deployed on Kubernetes.                                                                                                                                                                                                                                            |                                                                                       |
 | `config.existingCASecret`             | Name of the existing CA Secret.                                                                                                                                                                                                                                                                    |                                                                                       |
 | `config.generateSigningKey`           | Generate a signing key to sign jwt in proxy responses. Manual signing key can be set in values.                                                                                                                                                                                                    | `true`                                                                                |
 | `config.forceGenerateSigningKey`      | Force recreation of generated signing key. You will need to restart your deployments after running                                                                                                                                                                                                 | `false`                                                                               |
@@ -216,6 +217,10 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 ## Changelog
 
+### 8.0.0
+
+- Pomerium `ConfigMap` and `Secret` were combined into a single `Secret`. See [v8.0.0 Upgrade Nodes](#800-1) to migrate
+
 ### 7.0.0
 
 - Add automatic signing key generation.  See [v7.0.0 Upgrade Nodes](#700-1) to migrate
@@ -247,6 +252,17 @@ A full listing of Pomerium's configuration variables can be found on the [config
   - You must run pomerium v0.3.0+ to support this feature correctly
 
 ## Upgrading
+
+### 8.0.0
+
+- `config.existingConfig` `ConfigMap` has been merged with `config.existingSecret` `Secret`. All keys from `config.existingConfig` were moved to the `config.existingSecret`
+- `config.existingSecret` structure has been changed:
+
+  - all top level keys were moved under the `config.yaml` section
+  - naming of the top level keys was changed from `cookie-secret` to `cookie_secret` according to [the `config.yaml` format](https://www.pomerium.io/configuration/#shared-settings) (basically `'-'` was changed to the `'_'`)
+
+- `config.existingConfig` and `config.existingSecret` cannot be used separately anymore
+- If `config.existingConfig` and `config.existingSecret` options weren't used no actions are required
 
 ### 7.0.0
 

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -251,3 +251,19 @@ Adapted from : https://github.com/helm/charts/blob/master/stable/drone/templates
 {{- define "pomerium.operator.electionConfigMap" -}}
 {{- printf "%s-election" ( include "pomerium.operator.name" .) -}}
 {{- end -}}
+
+{{/*Expand the name of the config secret */}}
+{{- define "pomerium.secretName" -}}
+{{- if and .Values.config.existingSecret (not .Values.operator.enabled) -}}
+{{- .Values.config.existingSecret -}}
+{{- else -}}
+{{- include "pomerium.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*Expand the name of the config secret */}}
+{{- define "pomerium.baseSecretName" -}}
+{{- if .Values.operator.enabled -}}
+{{- default (printf "%s-base" (include "pomerium.fullname" .)) .Values.config.existingSecret -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pomerium/templates/authenticate-deployment.yaml
+++ b/charts/pomerium/templates/authenticate-deployment.yaml
@@ -1,5 +1,4 @@
-{{- $configName := default (include "pomerium.fullname" .) .Values.config.existingConfig }}
-{{- $secretName := default (include "pomerium.fullname" .) .Values.config.existingSecret }}
+{{- $secretName := include "pomerium.secretName" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,9 +53,7 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
-        {{- if or (or .Values.config.existingConfig .Values.config.policy) .Values.operator.enabled }}
           - --config=/etc/pomerium/config.yaml
-        {{- end }}
 {{- range $key, $value := .Values.extraArgs }}
 {{- if $value }}
           - --{{ $key }}={{ $value }}
@@ -71,39 +68,12 @@ spec:
           value: {{ default (printf "https://authenticate.%s" .Values.config.rootDomain ) .Values.proxy.authenticateServiceUrl }}
         - name: CACHE_SERVICE_URL
           value: {{ default (printf "https://%s.%s.svc.cluster.local" (include "pomerium.cache.fullname" .) .Release.Namespace ) .Values.authenticate.cacheServiceUrl}}
-        - name: COOKIE_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: {{ $secretName }}
-              key: cookie-secret
-        - name: SHARED_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: {{ $secretName }}
-              key: shared-secret
         - name: IDP_PROVIDER
           value: {{ .Values.authenticate.idp.provider }}
         - name: IDP_SCOPES
           value: {{ .Values.authenticate.idp.scopes }}
-        - name: IDP_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              name:  {{ $secretName }}
-              key: idp-client-id
-        - name: IDP_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name:  {{ $secretName }}
-              key: idp-client-secret
         - name: IDP_PROVIDER_URL
           value: {{ .Values.authenticate.idp.url }}
-{{- if .Values.authenticate.idp.serviceAccount }}
-        - name: IDP_SERVICE_ACCOUNT
-          valueFrom:
-            secretKeyRef:
-              name:  {{ $secretName }}
-              key: idp-service-account
-{{- end }}
         - name: CERTIFICATE_FILE
           value: "/pomerium/cert.pem"
         - name: CERTIFICATE_KEY_FILE
@@ -134,10 +104,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        {{- if or (or .Values.config.existingConfig .Values.config.policy) .Values.operator.enabled }}
         - mountPath: /etc/pomerium/
           name: config
-        {{- end }}
         - mountPath: /pomerium/cert.pem
           name: service-tls
           subPath: tls.crt
@@ -149,8 +117,8 @@ spec:
           subPath: ca.crt
       volumes:
       - name: config
-        configMap:
-          name: {{ $configName }}
+        secret:
+          secretName: {{ $secretName }}
       - name: service-tls
         secret:
           secretName: {{ template "pomerium.authenticate.tlsSecret.name" . }}

--- a/charts/pomerium/templates/authorize-deployment.yaml
+++ b/charts/pomerium/templates/authorize-deployment.yaml
@@ -1,5 +1,4 @@
-{{- $configName := default (include "pomerium.fullname" .) .Values.config.existingConfig }}
-{{- $secretName := default (include "pomerium.fullname" .) .Values.config.existingSecret }}
+{{- $secretName := include "pomerium.secretName" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -56,9 +55,7 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
-        {{- if or (or .Values.config.existingConfig .Values.config.policy) .Values.operator.enabled }}
           - --config=/etc/pomerium/config.yaml
-        {{- end }}
 {{- range $key, $value := .Values.extraArgs }}
 {{- if $value }}
           - --{{ $key }}={{ $value }}
@@ -69,11 +66,6 @@ spec:
         env:
         - name: SERVICES
           value: authorize
-        - name: SHARED_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: {{ $secretName }}
-              key: shared-secret
         - name: CERTIFICATE_FILE
           value: "/pomerium/cert.pem"
         - name: CERTIFICATE_KEY_FILE
@@ -101,10 +93,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        {{- if or (or .Values.config.existingConfig .Values.config.policy) .Values.operator.enabled }}
         - mountPath: /etc/pomerium/
           name: config
-        {{- end }}
         - mountPath: /pomerium/cert.pem
           name: service-tls
           subPath: tls.crt
@@ -116,8 +106,8 @@ spec:
           subPath: ca.crt
       volumes:
       - name: config
-        configMap:
-          name: {{ $configName }}
+        secret:
+          secretName: {{ $secretName }}
       - name: service-tls
         secret:
           secretName: {{ template "pomerium.authorize.tlsSecret.name" . }}

--- a/charts/pomerium/templates/cache-deployment.yaml
+++ b/charts/pomerium/templates/cache-deployment.yaml
@@ -1,5 +1,4 @@
-{{- $configName := default (include "pomerium.fullname" .) .Values.config.existingConfig }}
-{{- $secretName := default (include "pomerium.fullname" .) .Values.config.existingSecret }}
+{{- $secretName := include "pomerium.secretName" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,9 +53,7 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
-        {{- if or (or .Values.config.existingConfig .Values.config.policy) .Values.operator.enabled }}
           - --config=/etc/pomerium/config.yaml
-        {{- end }}
 {{- range $key, $value := .Values.extraArgs }}
 {{- if $value }}
           - --{{ $key }}={{ $value }}
@@ -69,11 +66,6 @@ spec:
           value: cache
         - name: CACHE_SERVICE_URL
           value: {{ default (printf "https://%s.%s.svc.cluster.local" (include "pomerium.cache.fullname" .) .Release.Namespace ) .Values.authenticate.cacheServiceUrl}}
-        - name: SHARED_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: {{ $secretName }}
-              key: shared-secret
         - name: CERTIFICATE_FILE
           value: "/pomerium/cert.pem"
         - name: CERTIFICATE_KEY_FILE
@@ -101,10 +93,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        {{- if or (or .Values.config.existingConfig .Values.config.policy) .Values.operator.enabled }}
         - mountPath: /etc/pomerium/
           name: config
-        {{- end }}
         - mountPath: /pomerium/cert.pem
           name: service-tls
           subPath: tls.crt
@@ -116,8 +106,8 @@ spec:
           subPath: ca.crt
       volumes:
       - name: config
-        configMap:
-          name: {{ $configName }}
+        secret:
+          secretName: {{ $secretName }}
       - name: service-tls
         secret:
           secretName: {{ template "pomerium.cache.tlsSecret.name" . }}

--- a/charts/pomerium/templates/configmap.yaml
+++ b/charts/pomerium/templates/configmap.yaml
@@ -1,71 +1,4 @@
-{{- if not .Values.config.existingConfig }}
 {{- if .Values.operator.enabled }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ template "pomerium.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ template "pomerium.name" . }}
-    helm.sh/chart: {{ template "pomerium.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-data:
-  config.yaml: ""
-
----
-{{- end }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  {{- if .Values.operator.enabled }}
-  name: {{ template "pomerium.fullname" . }}-base
-  {{- else }}
-  name: {{ template "pomerium.fullname" . }}
-  {{- end }}
-  labels:
-    app.kubernetes.io/name: {{ template "pomerium.name" . }}
-    helm.sh/chart: {{ template "pomerium.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-data:
-  config.yaml: |
-{{- if and .Values.config.existingPolicy .Values.config.extraOpts }}
-{{ fail "Cannot use config.extraOpts with config.existingPolicy" }}
-{{- end }}
-{{- if and .Values.config.existingPolicy .Values.config.policy }}
-{{ fail "Cannot use config.policy with config.existingPolicy" }}
-{{- end }}
-{{- if .Values.config.administrators }}
-    administrators: {{ .Values.config.administrators | quote }}
-{{- end -}}
-{{- if .Values.config.extraOpts }}
-{{ toYaml .Values.config.extraOpts | indent 4 -}}
-{{- end -}}
-{{- if .Values.metrics.enabled }}
-    metrics_address: :{{ .Values.metrics.port }}
-{{- end -}}
-{{- if .Values.tracing.enabled }}
-    tracing_debug: {{ .Values.tracing.debug }}
-    tracing_provider: {{ required "tracing_provider is required for tracing" .Values.tracing.provider }}
-
-{{- if eq .Values.tracing.provider "jaeger" }}
-    tracing_jaeger_collector_endpoint: {{ required "collector_endpoint is required for jaeoger tracing" .Values.tracing.jaeger.collector_endpoint }}
-    tracing_jaeger_agent_endpoint: {{ required "agent_endpoint is required for jaeger tracing" .Values.tracing.jaeger.agent_endpoint }}
-{{- end -}}
-
-{{- end -}}
-{{- if .Values.forwardAuth.enabled }}
-    forward_auth_url: https://{{ template "pomerium.forwardAuth.name" . }}
-{{- end -}}
-{{- if .Values.config.policy }}
-    policy:
-{{ toYaml .Values.config.policy | indent 6 }}
-{{- end -}}
-{{- end }}
-
-{{- if .Values.operator.enabled }}
----
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -75,5 +8,4 @@ metadata:
     helm.sh/chart: {{ template "pomerium.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-
 {{- end }}

--- a/charts/pomerium/templates/operator-deployment.yaml
+++ b/charts/pomerium/templates/operator-deployment.yaml
@@ -1,4 +1,5 @@
-{{- $configName := default (printf "%s-base" (include "pomerium.fullname" .)) .Values.config.existingConfig }}
+{{- $secretName := include "pomerium.secretName" . }}
+{{- $baseSecretName := include "pomerium.baseSecretName" . }}
 {{- if .Values.operator.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -64,6 +65,7 @@ spec:
           - --election-configmap={{ template "pomerium.operator.electionConfigMap" . }}
           - --election-namespace={{ .Release.Namespace }}
           - --election=true
+          - --pomerium-secret={{ $secretName }}
         ports:
           - containerPort: 8080
             name: metrics
@@ -88,8 +90,8 @@ spec:
           name: config
       volumes:
       - name: config
-        configMap:
-          name: {{ $configName }}
+        secret:
+          secretName: {{ $baseSecretName }}
       serviceAccountName: {{ template "pomerium.operator.serviceAccountName" . }}
 {{- if .Values.extraVolumes }}
 {{- toYaml .Values.extraVolumes | indent 8 }}

--- a/charts/pomerium/templates/proxy-deployment.yaml
+++ b/charts/pomerium/templates/proxy-deployment.yaml
@@ -1,5 +1,4 @@
-{{- $configName := default (include "pomerium.fullname" .) .Values.config.existingConfig }}
-{{- $secretName := default (include "pomerium.fullname" .) .Values.config.existingSecret }}
+{{- $secretName := include "pomerium.secretName" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -56,9 +55,7 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
-        {{- if or (or .Values.config.existingConfig .Values.config.policy) .Values.operator.enabled }}
           - --config=/etc/pomerium/config.yaml
-        {{- end }}
 {{- range $key, $value := .Values.extraArgs }}
 {{- if $value }}
           - --{{ $key }}={{ $value }}
@@ -69,16 +66,6 @@ spec:
         env:
         - name: SERVICES
           value: proxy
-        - name: COOKIE_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: {{ $secretName }}
-              key: cookie-secret
-        - name: SHARED_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: {{ $secretName }}
-              key: shared-secret
         - name: SIGNING_KEY
           valueFrom:
             secretKeyRef:
@@ -118,10 +105,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        {{- if or (or .Values.config.existingConfig .Values.config.policy) .Values.operator.enabled }}
         - mountPath: /etc/pomerium/
           name: config
-        {{- end }}
         - mountPath: /pomerium/cert.pem
           name: service-tls
           subPath: tls.crt
@@ -133,8 +118,8 @@ spec:
           subPath: ca.crt
       volumes:
       - name: config
-        configMap:
-          name: {{ $configName }}
+        secret:
+          secretName: {{ $secretName }}
       - name: service-tls
         secret:
           secretName: {{ template "pomerium.proxy.tlsSecret.name" . }}

--- a/charts/pomerium/templates/role.yaml
+++ b/charts/pomerium/templates/role.yaml
@@ -1,5 +1,5 @@
-{{- $configName := default (include "pomerium.fullname" .) .Values.config.existingConfig }}
-{{- $baseConfigName := default (printf "%s-base" (include "pomerium.fullname" .)) .Values.config.existingConfig }}
+{{- $secretName := include "pomerium.secretName" . }}
+{{- $baseSecretName := include "pomerium.baseSecretName" . }}
 
 {{- if and .Values.rbac.create .Values.operator.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -26,8 +26,9 @@ rules:
     resources:
       - configmaps
       - deployments
+      - secrets
     resourceNames:
-      - {{ $configName | quote }}
+      - {{ $secretName | quote }}
       - {{ template "pomerium.authenticate.fullname" . }}
       - {{ template "pomerium.authorize.fullname" . }}
       - {{ template "pomerium.proxy.fullname" . }}
@@ -39,14 +40,16 @@ rules:
       - watch
       - update
       - create
+{{- if $baseSecretName }}
   - apiGroups:
       - ""
     resources:
-      - configmaps
+      - secrets
     resourceNames:
-      - {{ $baseConfigName | quote }}
+      - {{ $baseSecretName | quote }}
     verbs:
       - get
       - list
       - watch
+{{- end -}}
 {{- end -}}

--- a/charts/pomerium/templates/secret.yaml
+++ b/charts/pomerium/templates/secret.yaml
@@ -1,20 +1,73 @@
-{{- if not .Values.config.existingSecret }}
+{{- if .Values.operator.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ template "pomerium.secretName" . }}
   labels:
     app.kubernetes.io/name: {{ template "pomerium.name" . }}
     helm.sh/chart: {{ template "pomerium.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  name: {{ template "pomerium.fullname" . }}
+stringData:
+  config.yaml: ""
+
+---
+{{- end }}
+
+{{- if not .Values.config.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  {{- if .Values.operator.enabled }}
+  name: {{ template "pomerium.baseSecretName" . }}
+  {{- else }}
+  name: {{ template "pomerium.secretName" . }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "pomerium.name" . }}
+    helm.sh/chart: {{ template "pomerium.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 type: Opaque
-data:
-  cookie-secret: {{ default (randAscii 32 | b64enc | b64enc) (.Values.config.cookieSecret | b64enc )}}
-  shared-secret: {{ default (randAscii 32 | b64enc | b64enc) (.Values.config.sharedSecret | b64enc )}}
-  idp-client-id: {{ .Values.authenticate.idp.clientID | b64enc }}
-  idp-client-secret: {{ .Values.authenticate.idp.clientSecret | b64enc }}
+stringData:
+  config.yaml: |
+{{- if and .Values.config.existingPolicy .Values.config.extraOpts }}
+{{ fail "Cannot use config.extraOpts with config.existingPolicy" }}
+{{- end }}
+{{- if and .Values.config.existingPolicy .Values.config.policy }}
+{{ fail "Cannot use config.policy with config.existingPolicy" }}
+{{- end }}
+{{- if .Values.config.administrators }}
+    administrators: {{ .Values.config.administrators | quote }}
+{{- end -}}
+{{- if .Values.config.extraOpts }}
+{{ toYaml .Values.config.extraOpts | indent 4 -}}
+{{- end -}}
+{{- if .Values.metrics.enabled }}
+    metrics_address: :{{ .Values.metrics.port }}
+{{- end -}}
+{{- if .Values.tracing.enabled }}
+    tracing_debug: {{ .Values.tracing.debug }}
+    tracing_provider: {{ required "tracing_provider is required for tracing" .Values.tracing.provider }}
+
+{{- if eq .Values.tracing.provider "jaeger" }}
+    tracing_jaeger_collector_endpoint: {{ required "collector_endpoint is required for jaeoger tracing" .Values.tracing.jaeger.collector_endpoint }}
+    tracing_jaeger_agent_endpoint: {{ required "agent_endpoint is required for jaeger tracing" .Values.tracing.jaeger.agent_endpoint }}
+{{- end -}}
+
+{{- end -}}
+{{- if .Values.forwardAuth.enabled }}
+    forward_auth_url: https://{{ template "pomerium.forwardAuth.name" . }}
+{{- end -}}
+{{- if .Values.config.policy }}
+    policy: 
+{{ toYaml .Values.config.policy | indent 6 }}
+{{- end }}
+    cookie_secret: {{ default (randAscii 32 | b64enc) .Values.config.cookieSecret }}
+    shared_secret: {{ default (randAscii 32 | b64enc) .Values.config.sharedSecret }}
+    idp_client_id: {{ .Values.authenticate.idp.clientID }}
+    idp_client_secret: {{ .Values.authenticate.idp.clientSecret }}
 {{- if .Values.authenticate.idp.serviceAccount }}
-  idp-service-account: {{ .Values.authenticate.idp.serviceAccount | b64enc }}
+    idp_service_account: {{ .Values.authenticate.idp.serviceAccount }}
 {{- end }}
 {{- end }}

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -9,7 +9,6 @@ config:
   # routes under this wildcard domain are handled by pomerium
   rootDomain: corp.beyondperimeter.com
   existingSecret: ""
-  existingConfig: ""
   existingCASecret: ""
   ca:
     cert: ""
@@ -108,7 +107,7 @@ operator:
   replicaCount: 1
   image:
     repository: "pomerium/pomerium-operator"
-    tag: "v0.0.1-rc1"
+    tag: "v0.0.1-rc2"
   config:
     ingressClass: pomerium
     serviceClass: pomerium


### PR DESCRIPTION
Fixes #67.
Fixes #71.

I've done my best with the naming, hope that config stored in the `Secret` is not confusing.

I haven't added automatic migration for the `existingConfig` option - I don't see an easy solution here.

I've used `stringData` for the new `Secret` - I think that it's a bit easier to read than the named template and conversion to `base64` but I can change it for consistency with the existing secrets from the chart.

I've bumped the chart version (not sure if I should do it).

`operator.image.tag` also should be changed after [the PR in the operator](https://github.com/pomerium/pomerium-operator/pull/44) will be merged.