### PR TITLE
Fix tls secrets keynames

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 6.0.2
+version: 6.0.3
 appVersion: 0.6.2
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/tls-secrets.yaml
+++ b/charts/pomerium/templates/tls-secrets.yaml
@@ -159,32 +159,33 @@ data:
   tls.crt: {{ $kp.Cert | b64enc }}
   tls.key: {{ $kp.Key | b64enc }}
 {{-   else if not .Values.config.generateTLS }}
-{{-     if and (not .Values.config.existingCASecret) .Values.config.ca }}
+{{-     if and (not .Values.config.existingCASecret) .Values.config.ca.cert .Values.config.ca.key }}
 {{ template "pomerium.ca.tlsSecretObject" . }}
-  {{ template "pomerium.caSecret.certName" . }}: {{ .Values.config.ca | b64enc }}
+  ca.crt: {{ .Values.config.ca.cert | b64enc }}
+  ca.key: {{ .Values.config.ca.key | b64enc }}
 {{-     end }}
 {{-     if and (not .Values.authenticate.existingTLSSecret) .Values.authenticate.tls.cert .Values.authenticate.tls.key }}
 ---
 {{ template "pomerium.authenticate.tlsSecretObject" . }}
-  {{ template "pomerium.authenticate.tlsSecret.certName" . }}: {{ .Values.authenticate.tls.cert | b64enc }}
-  {{ template "pomerium.authenticate.tlsSecret.keyName" . }}: {{ .Values.authenticate.tls.key | b64enc }}
+  tls.crt: {{ .Values.authenticate.tls.cert | b64enc }}
+  tls.key: {{ .Values.authenticate.tls.key | b64enc }}
 {{-     end }}
 {{-     if and (not .Values.authorize.existingTLSSecret) .Values.authorize.tls.cert .Values.authorize.tls.key }}
 ---
 {{ template "pomerium.authorize.tlsSecretObject" . }}
-  {{ template "pomerium.authorize.tlsSecret.certName" . }}: {{ .Values.authorize.tls.cert | b64enc }}
-  {{ template "pomerium.authorize.tlsSecret.keyName" . }}: {{ .Values.authorize.tls.key | b64enc }}
+  tls.crt: {{ .Values.authorize.tls.cert | b64enc }}
+  tls.key: {{ .Values.authorize.tls.key | b64enc }}
 {{-     end }}
 {{-     if and (not .Values.cache.existingTLSSecret) .Values.cache.tls.cert .Values.cache.tls.key }}
 ---
 {{ template "pomerium.cache.tlsSecretObject" . }}
-  {{ template "pomerium.cache.tlsSecret.certName" . }}: {{ .Values.cache.tls.cert | b64enc }}
-  {{ template "pomerium.cache.tlsSecret.keyName" . }}: {{ .Values.cache.tls.key | b64enc }}
+  tls.crt: {{ .Values.cache.tls.cert | b64enc }}
+  tls.key: {{ .Values.cache.tls.key | b64enc }}
 {{-     end }}
 {{-     if and (not .Values.proxy.existingTLSSecret) .Values.proxy.tls.cert .Values.proxy.tls.key }}
 ---
 {{ template "pomerium.proxy.tlsSecretObject" . }}
-  {{ template "pomerium.proxy.tlsSecret.certName" . }}: {{ .Values.proxy.tls.cert | b64enc }}
-  {{ template "pomerium.proxy.tlsSecret.keyName" . }}: {{ .Values.proxy.tls.key | b64enc }}
+  tls.crt: {{ .Values.proxy.tls.cert | b64enc }}
+  tls.key: {{ .Values.proxy.tls.key | b64enc }}
 {{-     end }}
 {{- end }}

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -11,6 +11,9 @@ config:
   existingSecret: ""
   existingConfig: ""
   existingCASecret: ""
+  ca:
+    cert: ""
+    key: ""
   sharedSecret: ""
   cookieSecret: ""
   generateTLS: true


### PR DESCRIPTION
close #72 

tls secrets keynames are hardcoded
also key and cert values can be specified for ca secret