### PR TITLE
Add helm hooks to operator-managed configmap

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 7.0.0
+version: 7.0.1
 appVersion: 0.6.2
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/configmap.yaml
+++ b/charts/pomerium/templates/configmap.yaml
@@ -9,6 +9,9 @@ metadata:
     helm.sh/chart: {{ template "pomerium.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook: pre-install
 data:
   config.yaml: ""
 


### PR DESCRIPTION
Without hooks, the operator-managed ConfigMap get nullified every apply.
This causes brief windows of outage, until the operator syncs the data back.