### PR TITLE
Fix cache service annotations indentation

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 7.0.0
+version: 7.0.1
 appVersion: 0.6.2
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/cache-service.yaml
+++ b/charts/pomerium/templates/cache-service.yaml
@@ -11,15 +11,17 @@ metadata:
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
-annotations:
-{{- if .Values.cache.service.annotations }}
- {{- range $key, $value := .Values.cache.service.annotations }}
-   {{ $key }}: {{ $value | quote }}
- {{- end }}
-{{- else if .Values.service.annotations }}
- {{- range $key, $value := .Values.service.annotations }}
-   {{ $key }}: {{ $value | quote }}
- {{- end }}
+{{- if or .Values.authenticate.service.annotations .Values.service.annotations }}
+  annotations:
+  {{- if .Values.cache.service.annotations }}
+  {{- range $key, $value := .Values.cache.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- else if .Values.service.annotations }}
+  {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 spec:
 {{- if .Values.service.cache.headless }}


### PR DESCRIPTION
Also add the same test in front of it as other services

I think I found it because helm 3 refuses such an error while helm 2 didn't, maybe we should add helm 3 tests too?