### PR TITLE
Do not provide config.yaml key in operator mode

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 8.5.2
+version: 8.5.3
 appVersion: 0.7.5
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/secret.yaml
+++ b/charts/pomerium/templates/secret.yaml
@@ -8,9 +8,6 @@ metadata:
     helm.sh/chart: {{ template "pomerium.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-stringData:
-  config.yaml: ""
-
 ---
 {{- end }}
 


### PR DESCRIPTION
When using the operator, prevent Helm v3's 3-way-merge from erasing the pomerium config secret upon upgrade.

closes #76 without relying on hooks.

