### PR TITLE
Fix: when `forwardAuth.internal == true` set also the namespace 

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 8.5.4
+version: 8.5.5
 appVersion: 0.7.6
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -245,6 +245,10 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 ## Changelog
 
+### 8.5.5
+
+- Fix: Set not only the service but also the namespace when `forwardAuth.internal == true`    
+
 ### 8.5.1
 
 - Add documentation for `extraOpts` flag, remove `policyFile` flag as it isn't implemented.

--- a/charts/pomerium/templates/secret.yaml
+++ b/charts/pomerium/templates/secret.yaml
@@ -54,7 +54,7 @@ stringData:
 
 {{- end -}}
 {{- if and .Values.forwardAuth.enabled .Values.forwardAuth.internal }}
-    forward_auth_url: https://{{ template "pomerium.proxy.fullname" . }}
+    forward_auth_url: https://{{ template "pomerium.proxy.fullname" . }}.{{ .Release.Namespace }}
 {{ else }}
     forward_auth_url: https://{{ template "pomerium.forwardAuth.name" . }}
 {{- end -}}


### PR DESCRIPTION
Fix: Set not only the service but also the namespace when `forwardAuth.internal == true`

