### PR TITLE
Static config checksum

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 9.3.0
+version: 9.4.0
 appVersion: 0.9.0
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/authenticate-deployment.yaml
+++ b/charts/pomerium/templates/authenticate-deployment.yaml
@@ -30,11 +30,9 @@ spec:
   template:
     metadata:
       annotations:
-        {{- /* policy is already covered by hot-reloading */}}
         {{- if not .Values.operator.enabled }}
-        checksum/config: {{ print .Values.config.extraOpts | sha256sum }}
+        checksum/secret: {{ include "pomerium.config.static" . | sha256sum }}
         {{- end }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}

--- a/charts/pomerium/templates/authorize-deployment.yaml
+++ b/charts/pomerium/templates/authorize-deployment.yaml
@@ -32,11 +32,9 @@ spec:
   template:
     metadata:
       annotations:
-        {{- /* policy is already covered by hot-reloading */}}
         {{- if not .Values.operator.enabled }}
-        checksum/config: {{ print .Values.config.extraOpts | sha256sum }}
+        checksum/secret: {{ include "pomerium.config.static" . | sha256sum }}
         {{- end }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}

--- a/charts/pomerium/templates/cache-deployment.yaml
+++ b/charts/pomerium/templates/cache-deployment.yaml
@@ -28,11 +28,9 @@ spec:
   template:
     metadata:
       annotations:
-        {{- /* policy is already covered by hot-reloading */}}
         {{- if not .Values.operator.enabled }}
-        checksum/config: {{ print .Values.config.extraOpts | sha256sum }}
+        checksum/secret: {{ include "pomerium.config.static" . | sha256sum }}
         {{- end }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}

--- a/charts/pomerium/templates/proxy-deployment.yaml
+++ b/charts/pomerium/templates/proxy-deployment.yaml
@@ -32,11 +32,9 @@ spec:
   template:
     metadata:
       annotations:
-        {{- /* policy is already covered by hot-reloading */}}
         {{- if not .Values.operator.enabled }}
-        checksum/config: {{ print .Values.config.extraOpts | sha256sum }}
+        checksum/secret: {{ include "pomerium.config.static" . | sha256sum }}
         {{- end }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}

--- a/charts/pomerium/templates/secret.yaml
+++ b/charts/pomerium/templates/secret.yaml
@@ -28,46 +28,6 @@ metadata:
 type: Opaque
 stringData:
   config.yaml: |
-    address: :{{ template "pomerium.trafficPort.number" . }}
-{{- if and .Values.config.existingPolicy .Values.config.extraOpts }}
-{{ fail "Cannot use config.extraOpts with config.existingPolicy" }}
-{{- end }}
-{{- if and .Values.config.existingPolicy .Values.config.policy }}
-{{ fail "Cannot use config.policy with config.existingPolicy" }}
-{{- end }}
-{{- if .Values.config.administrators }}
-    administrators: {{ .Values.config.administrators | quote }}
-{{- end -}}
-{{- if .Values.config.extraOpts }}
-{{ toYaml .Values.config.extraOpts | indent 4 -}}
-{{- end -}}
-{{- if .Values.metrics.enabled }}
-    metrics_address: :{{ .Values.metrics.port }}
-{{- end -}}
-{{- if .Values.tracing.enabled }}
-    tracing_debug: {{ .Values.tracing.debug }}
-    tracing_provider: {{ required "tracing_provider is required for tracing" .Values.tracing.provider }}
-
-{{- if eq .Values.tracing.provider "jaeger" }}
-    tracing_jaeger_collector_endpoint: {{ required "collector_endpoint is required for jaeoger tracing" .Values.tracing.jaeger.collector_endpoint }}
-    tracing_jaeger_agent_endpoint: {{ required "agent_endpoint is required for jaeger tracing" .Values.tracing.jaeger.agent_endpoint }}
-{{- end -}}
-
-{{- end -}}
-{{- if and .Values.forwardAuth.enabled .Values.forwardAuth.internal }}
-    forward_auth_url: https://{{ template "pomerium.proxy.fullname" . }}.{{ .Release.Namespace }}
-{{ else }}
-    forward_auth_url: https://{{ template "pomerium.forwardAuth.name" . }}
-{{- end -}}
-{{- if .Values.config.policy }}
-    policy:
-{{ toYaml .Values.config.policy | indent 6 }}
-{{- end }}
-    cookie_secret: {{ default (randAscii 32 | b64enc) .Values.config.cookieSecret }}
-    shared_secret: {{ default (randAscii 32 | b64enc) .Values.config.sharedSecret }}
-    idp_client_id: {{ .Values.authenticate.idp.clientID }}
-    idp_client_secret: {{ .Values.authenticate.idp.clientSecret }}
-{{- if .Values.authenticate.idp.serviceAccount }}
-    idp_service_account: {{ .Values.authenticate.idp.serviceAccount }}
-{{- end }}
+{{ include "pomerium.config.static" . |  indent 4 -}}
+{{ include "pomerium.config.dynamic" . | indent 4 -}}
 {{- end }}


### PR DESCRIPTION
After moving to a unified `Secret` for configuration storage, we were no longer checksumming only "static" values and forced a rollout for policy changes in addition to all other settings.

While many more settings beyond policy are now effectively dynamic in v0.9, this PR restores prior behavior: policy changes do not result in a deployment rollout.  More careful sorting of the options into static/dynamic buckets can be done in a future PR.