### PR TITLE
Running policy through helm's template function

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 9.4.0
+version: 9.4.1
 appVersion: 0.9.0
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 9.3.0
+version: 9.3.1
 appVersion: 0.9.0
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -343,6 +343,6 @@ idp_service_account: {{ .Values.authenticate.idp.serviceAccount }}
 {{- define "pomerium.config.dynamic" -}}
 {{- if .Values.config.policy }}
 policy:
-{{ toYaml .Values.config.policy | indent 2 }}
+{{ tpl (toYaml .Values.config.policy) . | indent 2 }}
 {{- end }}
 {{- end -}}

--- a/charts/pomerium/templates/secret.yaml
+++ b/charts/pomerium/templates/secret.yaml
@@ -61,7 +61,7 @@ stringData:
 {{- end -}}
 {{- if .Values.config.policy }}
     policy:
-{{ toYaml .Values.config.policy | indent 6 }}
+{{ tpl (toYaml .Values.config.policy) . | indent 6 }}
 {{- end }}
     cookie_secret: {{ default (randAscii 32 | b64enc) .Values.config.cookieSecret }}
     shared_secret: {{ default (randAscii 32 | b64enc) .Values.config.sharedSecret }}


### PR DESCRIPTION
Running the policy through helm's tpl function would allow for install-time overrides for policy parameters.

For example, if all your "from" urls have a base url that changes in every environment it would be useful to pass something like `cluster.baseUrl` as a --set parameter.