### PR TITLE
Reorganize shared/common deployment settings

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 9.4.0
+version: 10.0.0
 appVersion: 0.9.0
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -16,6 +16,7 @@
     - [Self Provisioned](#self-provisioned-1)
   - [Configuration](#configuration)
   - [Changelog](#changelog)
+    - [10.0.0](#1000)
     - [8.5.5](#855)
     - [8.5.1](#851)
     - [8.5.0](#850)
@@ -28,6 +29,7 @@
     - [3.0.0](#300)
     - [2.0.0](#200)
   - [Upgrading](#upgrading)
+    - [10.0.0](#1000-1)
     - [8.0.0](#800-1)
     - [7.0.0](#700-1)
     - [5.0.0](#500-1)
@@ -36,7 +38,7 @@
     - [2.0.0](#200-1)
   - [Metrics Discovery Configuration](#metrics-discovery-configuration)
     - [Prometheus Operator](#prometheus-operator)
-    - [Prometheus kubernetes_sd_configs](#prometheus-kubernetessdconfigs)
+    - [Prometheus kubernetes_sd_configs](#prometheus-kubernetes_sd_configs)
 
 ## TL;DR;
 
@@ -246,6 +248,10 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 ## Changelog
 
+### 10.0.0
+
+- Refactor shared configuration logic to be driven by named templates. See [v10.0.0 Upgrade Nodes](#1000-1) to migrate.
+
 ### 8.5.5
 
 - Fix: Set not only the service but also the namespace when `forwardAuth.internal == true`    
@@ -297,6 +303,32 @@ A full listing of Pomerium's configuration variables can be found on the [config
   - You must run pomerium v0.3.0+ to support this feature correctly
 
 ## Upgrading
+
+### 10.0.0
+
+- All shared configuration has been moved from ENV vars to a configuration file.  Users of `config.existingSecret` must specify **all** parameters in their secret or leverage `extraEnv` to pass in overrides.  
+  
+  Some of the impacted chart values and their equivilent settings are listed below:
+
+  | Chart Value                    | Config Parameter                    |
+  | ------------------------------ | ----------------------------------- |
+  | `authenticate.idp.provider`    | `idp_provider`                      |
+  | `authenticate.idp.url`         | `idp_provider_url`                  |
+  | `authenticate.cacheServiceUrl` | `cache_service_url`                 |
+  | `authenticate.idp.scopes`      | `idp_scopes`                        |
+  | `config.insecure`              | `insecure_server` + `grpc_insecure` |
+  | `proxy.authenticateServiceUrl` | `authenticate_service_url`          |
+  | `proxy.authorizeInternalUrl`   | `authorize_service_url`             |
+
+  Other settings required in your `config.existingSecret` or `extraEnv`:
+
+  - `CACHE_SERVICE_URL=[your cache service url]`
+  - `AUTHENTICATE_SERVICE_URL=[your authenticate service url]`
+  - `CERTIFICATE_FILE="/pomerium/cert.pem"`
+  - `CERTIFICATE_KEY_FILE="/pomerium/privkey.pem"`
+  - `CERTIFICATE_AUTHORITY_FILE="/pomerium/ca.pem"`
+
+  If you are not using `config.existingSecret` you should not need to make any changes.
 
 ### 8.0.0
 

--- a/charts/pomerium/templates/authenticate-deployment.yaml
+++ b/charts/pomerium/templates/authenticate-deployment.yaml
@@ -1,4 +1,3 @@
-{{- $secretName := include "pomerium.secretName" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -64,28 +63,6 @@ spec:
         env:
         - name: SERVICES
           value: authenticate
-        - name: AUTHENTICATE_SERVICE_URL
-          value: {{ default (printf "https://authenticate.%s" .Values.config.rootDomain ) .Values.proxy.authenticateServiceUrl }}
-        - name: CACHE_SERVICE_URL
-          value: {{ default (printf "https://%s.%s.svc.cluster.local" (include "pomerium.cache.fullname" .) .Release.Namespace ) .Values.authenticate.cacheServiceUrl}}
-        - name: IDP_PROVIDER
-          value: {{ .Values.authenticate.idp.provider }}
-        - name: IDP_SCOPES
-          value: {{ .Values.authenticate.idp.scopes }}
-        - name: IDP_PROVIDER_URL
-          value: {{ .Values.authenticate.idp.url }}
-        - name: CERTIFICATE_FILE
-          value: "/pomerium/cert.pem"
-        - name: CERTIFICATE_KEY_FILE
-          value: "/pomerium/privkey.pem"
-        - name: CERTIFICATE_AUTHORITY_FILE
-          value: "/pomerium/ca.pem"
-{{- if .Values.config.insecure }}
-        - name: INSECURE_SERVER
-          value: "true"
-        - name: GRPC_INSECURE
-          value: "true"
-{{- end }}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}
           value: {{ quote $value }}
@@ -101,47 +78,21 @@ spec:
           httpGet:
             path: /ping
             port: {{ template "pomerium.trafficPort.name" . }}
-{{- if .Values.config.insecure }}
-            scheme: HTTP
-{{- else }}
-            scheme: HTTPS
-{{- end }}
+            scheme: {{ upper (include "pomerium.trafficPort.name" .) }}
         readinessProbe:
           httpGet:
             path: /ping
             port: {{ template "pomerium.trafficPort.name" . }}
-{{- if .Values.config.insecure }}
-            scheme: HTTP
-{{- else }}
-            scheme: HTTPS
-{{- end }}
+            scheme: {{ upper (include "pomerium.trafficPort.name" .) }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /etc/pomerium/
-          name: config
-        - mountPath: /pomerium/cert.pem
-          name: service-tls
-          subPath: tls.crt
-        - mountPath: /pomerium/privkey.pem
-          name: service-tls
-          subPath: tls.key
-        - mountPath: /pomerium/ca.pem
-          name: ca-tls
-          subPath: ca.crt
+{{ include "pomerium.volumeMounts" . | indent 10 }}
       volumes:
-      - name: config
-        secret:
-          secretName: {{ $secretName }}
-      - name: service-tls
-        secret:
-          secretName: {{ template "pomerium.authenticate.tlsSecret.name" . }}
-      - name: ca-tls
-        secret:
-          secretName: {{ template "pomerium.caSecret.name" . }}
-{{- if .Values.extraVolumes }}
-{{- toYaml .Values.extraVolumes | indent 8 }}
-{{- end }}
+{{ include "pomerium.volumes.shared" . | indent 8 }}
+{{- $ctx := . }}
+{{- $_ := set $ctx "currentServiceName" "authenticate" }}
+{{ include "pomerium.volumes.service" $ctx | indent 8 }}
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/pomerium/templates/authorize-deployment.yaml
+++ b/charts/pomerium/templates/authorize-deployment.yaml
@@ -1,4 +1,3 @@
-{{- $secretName := include "pomerium.secretName" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -66,20 +65,6 @@ spec:
         env:
         - name: SERVICES
           value: authorize
-        - name: CERTIFICATE_FILE
-          value: "/pomerium/cert.pem"
-        - name: CERTIFICATE_KEY_FILE
-          value: "/pomerium/privkey.pem"
-        - name: CERTIFICATE_AUTHORITY_FILE
-          value: "/pomerium/ca.pem"
-        - name: AUTHENTICATE_SERVICE_URL
-          value: {{ default (printf "https://authenticate.%s" .Values.config.rootDomain ) .Values.proxy.authenticateServiceUrl }}
-{{- if .Values.config.insecure }}
-        - name: INSECURE_SERVER
-          value: "true"
-        - name: GRPC_INSECURE
-          value: "true"
-{{- end }}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}
           value: {{ quote $value }}
@@ -101,31 +86,12 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /etc/pomerium/
-          name: config
-        - mountPath: /pomerium/cert.pem
-          name: service-tls
-          subPath: tls.crt
-        - mountPath: /pomerium/privkey.pem
-          name: service-tls
-          subPath: tls.key
-        - mountPath: /pomerium/ca.pem
-          name: ca-tls
-          subPath: ca.crt
+{{ include "pomerium.volumeMounts" . | indent 10 }}
       volumes:
-      - name: config
-        secret:
-          secretName: {{ $secretName }}
-      - name: service-tls
-        secret:
-          secretName: {{ template "pomerium.authorize.tlsSecret.name" . }}
-      - name: ca-tls
-        secret:
-          secretName: {{ template "pomerium.caSecret.name" . }}
-{{- if .Values.extraVolumes }}
-      volumes:
-{{- toYaml .Values.extraVolumes | indent 8 }}
-{{- end }}
+{{ include "pomerium.volumes.shared" . | indent 8 }}
+{{- $ctx := . }}
+{{- $_ := set $ctx "currentServiceName" "authorize" }}
+{{ include "pomerium.volumes.service" $ctx | indent 8 }}
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/pomerium/templates/cache-deployment.yaml
+++ b/charts/pomerium/templates/cache-deployment.yaml
@@ -1,4 +1,3 @@
-{{- $secretName := include "pomerium.secretName" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -62,20 +61,6 @@ spec:
         env:
         - name: SERVICES
           value: cache
-        - name: CACHE_SERVICE_URL
-          value: {{ default (printf "https://%s.%s.svc.cluster.local" (include "pomerium.cache.fullname" .) .Release.Namespace ) .Values.authenticate.cacheServiceUrl}}
-        - name: CERTIFICATE_FILE
-          value: "/pomerium/cert.pem"
-        - name: CERTIFICATE_KEY_FILE
-          value: "/pomerium/privkey.pem"
-        - name: CERTIFICATE_AUTHORITY_FILE
-          value: "/pomerium/ca.pem"
-{{- if .Values.config.insecure }}
-        - name: INSECURE_SERVER
-          value: "true"
-        - name: GRPC_INSECURE
-          value: "true"
-{{- end }}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}
           value: {{ quote $value }}
@@ -97,31 +82,12 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /etc/pomerium/
-          name: config
-        - mountPath: /pomerium/cert.pem
-          name: service-tls
-          subPath: tls.crt
-        - mountPath: /pomerium/privkey.pem
-          name: service-tls
-          subPath: tls.key
-        - mountPath: /pomerium/ca.pem
-          name: ca-tls
-          subPath: ca.crt
+{{ include "pomerium.volumeMounts" . | indent 10 }}
       volumes:
-      - name: config
-        secret:
-          secretName: {{ $secretName }}
-      - name: service-tls
-        secret:
-          secretName: {{ template "pomerium.cache.tlsSecret.name" . }}
-      - name: ca-tls
-        secret:
-          secretName: {{ template "pomerium.caSecret.name" . }}
-{{- if .Values.extraVolumes }}
-      volumes:
-{{- toYaml .Values.extraVolumes | indent 8 }}
-{{- end }}
+{{ include "pomerium.volumes.shared" . | indent 8 }}
+{{- $ctx := . }}
+{{- $_ := set $ctx "currentServiceName" "cache" }}
+{{ include "pomerium.volumes.service" $ctx | indent 8 }}
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/pomerium/templates/proxy-deployment.yaml
+++ b/charts/pomerium/templates/proxy-deployment.yaml
@@ -1,4 +1,3 @@
-{{- $secretName := include "pomerium.secretName" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,22 +70,6 @@ spec:
             secretKeyRef:
               name: {{ template "pomerium.proxy.signingKeySecret.name" . }}
               key: signing-key
-        - name: AUTHENTICATE_SERVICE_URL
-          value: {{ default (printf "https://authenticate.%s" .Values.config.rootDomain ) .Values.proxy.authenticateServiceUrl }}
-        - name: AUTHORIZE_SERVICE_URL
-          value: {{ default (printf "https://%s.%s.svc.cluster.local" (include "pomerium.authorize.fullname" .) .Release.Namespace ) .Values.proxy.authorizeInternalUrl}}
-        - name: CERTIFICATE_FILE
-          value: "/pomerium/cert.pem"
-        - name: CERTIFICATE_KEY_FILE
-          value: "/pomerium/privkey.pem"
-        - name: CERTIFICATE_AUTHORITY_FILE
-          value: "/pomerium/ca.pem"
-{{- if .Values.config.insecure }}
-        - name: INSECURE_SERVER
-          value: "true"
-        - name: GRPC_INSECURE
-          value: "true"
-{{- end }}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}
           value: {{ quote $value }}
@@ -102,48 +85,21 @@ spec:
           httpGet:
             path: /ping
             port: {{ template "pomerium.trafficPort.name" . }}
-{{- if .Values.config.insecure }}
-            scheme: HTTP
-{{- else }}
-            scheme: HTTPS
-{{- end }}
+            scheme: {{ upper (include "pomerium.trafficPort.name" .) }}
         readinessProbe:
           httpGet:
             path: /ping
             port: {{ template "pomerium.trafficPort.name" . }}
-{{- if .Values.config.insecure }}
-            scheme: HTTP
-{{- else }}
-            scheme: HTTPS
-{{- end }}
+            scheme: {{ upper (include "pomerium.trafficPort.name" .) }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /etc/pomerium/
-          name: config
-        - mountPath: /pomerium/cert.pem
-          name: service-tls
-          subPath: tls.crt
-        - mountPath: /pomerium/privkey.pem
-          name: service-tls
-          subPath: tls.key
-        - mountPath: /pomerium/ca.pem
-          name: ca-tls
-          subPath: ca.crt
+{{ include "pomerium.volumeMounts" . | indent 10 }}
       volumes:
-      - name: config
-        secret:
-          secretName: {{ $secretName }}
-      - name: service-tls
-        secret:
-          secretName: {{ template "pomerium.proxy.tlsSecret.name" . }}
-      - name: ca-tls
-        secret:
-          secretName: {{ template "pomerium.caSecret.name" . }}
-{{- if .Values.extraVolumes }}
-      volumes:
-{{- toYaml .Values.extraVolumes | indent 8 }}
-{{- end }}
+{{ include "pomerium.volumes.shared" . | indent 8 }}
+{{- $ctx := . }}
+{{- $_ := set $ctx "currentServiceName" "proxy" }}
+{{ include "pomerium.volumes.service" $ctx | indent 8 }}
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}


### PR DESCRIPTION
This PR is an attempt to consolidate shared settings into the config yaml file out of ENV vars.  This allows logic to be centralized and permits further breakdown of templating.

Details:

- Move all current ENV vars to static config section, except the `SERVICES` var
- Move volumeMounts to a new named template
- Move common volumes to a new named template
- Move service-specific volumes to a new named template
- Derive scheme for `authorize` and `cache` URLs from templates
- Ensure we're setting the `grpc_address` correctly
- Derive probe scheme from templates
- Mark TLS related volumes optional to support insecure mode more easily

NB: the way `$ctx` is constructed to pass down a service name to `pomerium.volumes.service` feels gross.  Not sure if there's a cleaner way.

/cc @Vad1mo @lukasmrtvy as this fixes some (all?) issues with insecure logic.