### PR TITLE
Running policy template through helm's tpl function in order to dynam…

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 10.0.0
+version: 10.0.1
 appVersion: 0.9.0
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -368,7 +368,7 @@ idp_service_account: {{ .Values.authenticate.idp.serviceAccount }}
 {{- define "pomerium.config.dynamic" -}}
 {{- if .Values.config.policy }}
 policy:
-{{ toYaml .Values.config.policy | indent 2 }}
+{{ tpl (toYaml .Values.config.policy) . | indent 2 }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
Running the policy through helm's tpl function would allow for install-time overrides for policy parameters.

For example, if all your "from" urls have a base url that changes in every environment it would be useful to pass something like cluster.baseUrl as a --set parameter.

Signed-off-by: Bjoern Weidlich <bweidlich@ripple.com>