### PR TITLE
Prevent Helm output error when using environment variables to set identity provider credentials

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 10.0.2
+version: 10.0.3
 appVersion: 0.9.2
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/NOTES.txt
+++ b/charts/pomerium/templates/NOTES.txt
@@ -36,9 +36,12 @@ This deployment will be incomplete until you configure a valid identity provider
 
 Currently supported providers:
 
-    - Okta
-    - Google
     - Azure Active Directory
+    - AWS Cognito
+    - GitHub
+    - GitLab
+    - Google
+    - Okta
     - OneLogin
 
 See the values.yaml file to see what values are required for each provider.

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -140,6 +140,8 @@ Adapted from : https://github.com/helm/charts/blob/master/stable/drone/templates
 {{- if .Values.authenticate.idp -}}
   {{- if .Values.config.existingSecret -}}
   true
+  {{- else if and .Values.extraEnv.IDP_CLIENT_ID .Values.extraEnv.IDP_CLIENT_SECRET -}}
+  true
   {{- else if eq .Values.authenticate.idp.clientID "" -}}
   false
   {{- else if eq .Values.authenticate.idp.clientSecret "" -}}


### PR DESCRIPTION
## What

- Update `pomerium.providerOK` in `_helpers.tpl` to consider identity provider credentials set via environment variables as valid (to prevent generating an invalid error message).
- Update the list of valid identity providers that is shown, in the case that invalid identity provider credentials actually are provided.

## Why

- Fixes #119
- An error message should not be displayed when valid input is provided.