### PR TITLE
updated values in helm chart to use the latest image

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pomerium
-version: 10.1.3
-appVersion: 0.9.2
+version: 10.1.4
+appVersion: 0.9.4
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg
 description: Pomerium is an identity-aware access proxy.

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -224,7 +224,7 @@ imagePullSecrets: ""
 
 image:
   repository: "pomerium/pomerium"
-  tag: "v0.9.2"
+  tag: "v0.9.4"
   pullPolicy: "IfNotPresent"
 
 metrics:


### PR DESCRIPTION
noticed that helm chart was pointing to `v0.9.2` and the latest release is `v0.9.4`