### PR TITLE
fix whitespace in clusterrolebinding.yaml

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 11.2.1
+version: 11.2.2
 appVersion: 0.9.5
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/clusterrolebinding.yaml
+++ b/charts/pomerium/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.operator.enabled -}}
+{{- if and .Values.rbac.create .Values.operator.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,11 +17,11 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "pomerium.operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}
 
 ---
 
-{{- if and .Values.rbac.create .Values.apiProxy.enabled -}}
+{{- if and .Values.rbac.create .Values.apiProxy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -39,4 +39,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.authorize.serviceAccount.name }}
     namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}


### PR DESCRIPTION
Fix error when using `apiProxy` and `operator` features at the same time.