### PR TITLE
Fix whitespace in cluster role template

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 11.2.2
+version: 11.2.3
 appVersion: 0.9.5
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/clusterrole.yaml
+++ b/charts/pomerium/templates/clusterrole.yaml
@@ -37,7 +37,7 @@ rules:
       - get
       - list
       - watch
-{{- end -}}
+{{- end }}
 
 ---
 


### PR DESCRIPTION
Fixes issue where whitespace is removed and `watch` verb in cluster role template ends up as `watch---` 