### PR TITLE
Raise (commented out) CPU and memory limits.

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 12.2.0
+version: 12.2.1
 appVersion: 0.10.0
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -225,8 +225,8 @@ ingress:
 resources:
   {}
   # limits:
-  #   cpu: 100m
-  #   memory: 300Mi
+  #   cpu: 1
+  #   memory: 600Mi
   # requests:
   #   cpu: 100m
   #   memory: 300Mi


### PR DESCRIPTION
Too low limits can cause starvation and startup issues.  Suggest a higher
limit to prevent it.  See pomerium/pomerium#1337 for more details.