### PR TITLE
fix: probes should only use http or https schemes

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 12.2.1
+version: 12.2.2
 appVersion: 0.10.0
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 12.2.2
+version: 12.2.3
 appVersion: 0.10.0
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -322,6 +322,15 @@ Adapted from : https://github.com/helm/charts/blob/master/stable/drone/templates
 {{- end -}}
 {{- end -}}
 
+{{/*Expand the http port scheme for secure or insecure mode */}}
+{{- define "pomerium.httpTrafficPort.scheme" -}}
+{{- if .Values.config.insecure -}}
+http
+{{- else -}}
+https
+{{- end -}}
+{{- end -}}
+
 {{/*
 Expand the grpc port name for secure or insecure mode
 

--- a/charts/pomerium/templates/authenticate-deployment.yaml
+++ b/charts/pomerium/templates/authenticate-deployment.yaml
@@ -91,12 +91,12 @@ spec:
           httpGet:
             path: /ping
             port: {{ template "pomerium.httpTrafficPort.name" . }}
-            scheme: {{ upper (include "pomerium.httpTrafficPort.name" .) }}
+            scheme: {{ upper (include "pomerium.httpTrafficPort.scheme" .) }}
         readinessProbe:
           httpGet:
             path: /ping
             port: {{ template "pomerium.httpTrafficPort.name" . }}
-            scheme: {{ upper (include "pomerium.httpTrafficPort.name" .) }}
+            scheme: {{ upper (include "pomerium.httpTrafficPort.scheme" .) }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/charts/pomerium/templates/proxy-deployment.yaml
+++ b/charts/pomerium/templates/proxy-deployment.yaml
@@ -88,12 +88,12 @@ spec:
           httpGet:
             path: /ping
             port: {{ template "pomerium.httpTrafficPort.name" . }}
-            scheme: {{ upper (include "pomerium.httpTrafficPort.name" .) }}
+            scheme: {{ upper (include "pomerium.httpTrafficPort.scheme" .) }}
         readinessProbe:
           httpGet:
             path: /ping
             port: {{ template "pomerium.httpTrafficPort.name" . }}
-            scheme: {{ upper (include "pomerium.httpTrafficPort.name" .) }}
+            scheme: {{ upper (include "pomerium.httpTrafficPort.scheme" .) }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:


### PR DESCRIPTION
Signed-off-by: Hugo Cortes <contact@hugocortes.dev>

## Summary
<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->
Proxy and Authenticate deployments will be rejected when providing `service.httpTrafficPort.nameOverride=http2` as per instructions when using istio with mtls. The error returned is:
```sh
spec.template.spec.containers[0].livenessProbe.httpGet.scheme: Unsupported value: "HTTP2": supported values: "HTTP", "HTTPS
```

This fix simply adds a `pomerium.httpTrafficPort.scheme` template which is dependent on `config.insecure` and will be used by readiness and liveness probe schemes

## Related issues
<!-- For example...
Fixes #159 
-->
Possible fix for #141 
* I first experienced the same 500 error when setting `config.insecure=true` without the http2 name override. Awaiting confirmation that this chart fix resolves issue.


**Checklist**:
- [x] add related issues
~- [ ] update Configuration in README~ n/a
~- [ ] update Changelog in README (major versions)~ n/a
~- [ ] update Upgrading in README (breaking changes)~ n/a
- [x] ready for review
