### PR TITLE
ingress: prevent tls host generation from policy in forward auth mode

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 12.2.1
+version: 12.2.2
 appVersion: 0.10.0
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/ingress.yaml
+++ b/charts/pomerium/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
         {{- if and (.Values.forwardAuth.enabled) (not .Values.forwardAuth.internal) }}
         - {{ template "pomerium.forwardAuth.name" . }}
         {{ end }}
-      {{- if not .Values.ingress.hosts }}
+      {{- if not (or .Values.ingress.hosts .Values.forwardAuth.enabled) }}
       {{- range .Values.config.policy }}
         - {{ .from | trimPrefix "https://" | trimPrefix "http://" | quote }}
       {{- end }}


### PR DESCRIPTION
## Summary
We don't generate `rules` entries from policy when `ingress.hosts` or `forwardAuth.enabled` are set.  We should also prevent generation of `tls.hosts` in the same situations.  

At best it is a cosmetic error, at worst it could misroute traffic or create unnecessary TLS certificates.

**Checklist**:
- [x] ready for review
