### PR TITLE
fix static signingKey

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 12.5.0
+version: 13.0.0
 appVersion: 0.10.6
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -138,7 +138,7 @@ You may force recreation of your signing key by setting `config.forceGenerateSig
 If you wish to provide your own signing key in secret, you should:
 
 1. turn `config.generateSigningKey` to `false`
-2. specify `config.existingsigningKeySecret` with secret's name
+2. specify `config.existingSigningKeySecret` with secret's name
 
 ## Kubernetes API Proxy
 

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -18,6 +18,7 @@
   - [Redis Subchart](#redis-subchart)
   - [Configuration](#configuration)
   - [Changelog](#changelog)
+    - [13.0.0](#1300)
     - [11.0.0](#1100)
     - [10.2.0](#1020)
     - [10.0.0](#1000)
@@ -33,6 +34,7 @@
     - [3.0.0](#300)
     - [2.0.0](#200)
   - [Upgrading](#upgrading)
+    - [13.0.0](#1300)
     - [12.3.0](#1230)
     - [11.0.0](#1100-1)
     - [10.0.0](#1000-1)
@@ -361,6 +363,10 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 ## Changelog
 
+### 13.0.0
+
+- `config.existingSigningKeySecret` updated to have correct camelCase. Additionally uses of `authorize.existingsigningKeySecret` and `authorize.signingKey` have been updated to the correct `config.` block. See [v13.0.0 Upgrade Nodes](#1300-1) to migrate.
+
 ### 11.0.0
 
 - Signing key has been refactored to correspond with Pomerium changes. See [v11.0.0 Upgrade Nodes](#1100-1) to migrate.
@@ -425,13 +431,19 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 ## Upgrading
 
+### 13.0.0
+
+- `existingsigningKeySecret` has been corrected to `existingSigningKeySecret` and properly standardized to the `config` block in all use cases.
+  - If you were specifying `config.existingsigningKeySecret`, update the value to the correct casing.
+  - If you were using `authorize.existingsigningKeySecret` and `authorize.signingKey` to create a signing key with the value from `config.signingKey` there should not be an impact, but the deprecated values can be removed.
+
 ### 12.3.0
 
 - If using the new `redis` support and you wish to use the automatic tls generation, set `redis.forceGenerateTLS` to ensure the new secrets are generated.  After the upgrade is complete, you should set `redis.forceGenerateTLS` to `false` (the default) again.
 
 ### 11.0.0
 
-- SigningKey is now under the `authorize` block.  
+- SigningKey is now under the `config` block.  
   - If you are specifying `proxy.signingKeySecret` or `proxy.existingSigningKeySecret`, please change the values to be `config.signingKeySecret` or `config.existingSigningKeySecret`
   - If were relying on automatic signing key generation do one of the following:
     1. set `config.forceGenerateSigningKey` to `true` for the upgrade

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -218,8 +218,8 @@ Adapted from : https://github.com/helm/charts/blob/master/stable/drone/templates
 
 {{/* Determine secret name for signing key */}}
 {{- define "pomerium.signingKeySecret.name" -}}
-{{- if .Values.config.existingsigningKeySecret -}}
-{{- .Values.config.existingsigningKeySecret | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.config.existingSigningKeySecret -}}
+{{- .Values.config.existingSigningKeySecret | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}

--- a/charts/pomerium/templates/signing-key-secret.yaml
+++ b/charts/pomerium/templates/signing-key-secret.yaml
@@ -23,7 +23,7 @@ data:
 {{ template "pomerium.signingKeySecretObject" . }}
   signing-key: {{ genPrivateKey "ecdsa" | b64enc | b64enc }}
 {{-   else if not .Values.config.generateSigningKey }}
-{{-     if and (not .Values.authorize.existingsigningKeySecret) .Values.authorize.signingKey }}
+{{-     if and (not .Values.config.existingsigningKeySecret) .Values.config.signingKey }}
 {{ template "pomerium.signingKeySecretObject" . }}
   signing-key: {{ .Values.config.signingKey | b64enc }}
 {{-     end }}

--- a/charts/pomerium/templates/signing-key-secret.yaml
+++ b/charts/pomerium/templates/signing-key-secret.yaml
@@ -23,7 +23,7 @@ data:
 {{ template "pomerium.signingKeySecretObject" . }}
   signing-key: {{ genPrivateKey "ecdsa" | b64enc | b64enc }}
 {{-   else if not .Values.config.generateSigningKey }}
-{{-     if and (not .Values.config.existingsigningKeySecret) .Values.config.signingKey }}
+{{-     if and (not .Values.config.existingSigningKeySecret) .Values.config.signingKey }}
 {{ template "pomerium.signingKeySecretObject" . }}
   signing-key: {{ .Values.config.signingKey | b64enc }}
 {{-     end }}


### PR DESCRIPTION
- Update references from authorize.signingKey to config.signingKey
- Fix camelCase for existingSigningKeySecret value
- Bump version and add upgrade notes

## Summary
<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->
This corrects some dangling usage of the `authorize` block for signing key values, and fixes the camelCase of existingSigningKeySecret everywhere.

Technically this could break existing usage of the "incorrect" values, so I've given it a major version bump to ensure users are not unexpectedly impacted.

## Related issues
<!-- For example...
Fixes #159 
-->
Didn't open an issue, discussed in slack


**Checklist**:
- [ ] add related issues
- [x] update Configuration in README
- [x] update Changelog in README (major versions)
- [x] update Upgrading in README (breaking changes)
- [x] ready for review
