### PR TITLE
Use randAlphaNum 10 for default Redis password

### DIFF
--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -543,7 +543,7 @@ redis
 {{- else if .Values.config.sharedSecret -}}
 {{-  .Values.config.sharedSecret | sha256sum -}}
 {{- else -}}
-{{- randAscii 32 -}}
+{{- randAlphaNum 10 -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
This matches [the default value used by Bitnami's upstream Redis chart][1].

[1]: https://github.com/bitnami/charts/blob/master/bitnami/redis/templates/_helpers.tpl#L231

Using non-alphanumeric characters in the Redis password is liable to introduce characters that break URL parsing in the databroker storage connection string.

## Related issues

Issues with URL-unsafe characters were observed in #167

**Checklist**:
- [x] add related issues
- [x] ready for review
