### PR TITLE
Refactor to derive secrets from existing secrets in cluster

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 13.1.0
+version: 14.0.0
 appVersion: 0.10.6
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo-long.svg

--- a/charts/pomerium/templates/authenticate-deployment.yaml
+++ b/charts/pomerium/templates/authenticate-deployment.yaml
@@ -68,6 +68,7 @@ spec:
             secretKeyRef:
               name: {{ template "pomerium.signingKeySecret.name" . }}
               key: signing-key
+{{  include "pomerium.sharedEnv" . | indent 8 }}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}
           value: {{ quote $value }}

--- a/charts/pomerium/templates/authorize-deployment.yaml
+++ b/charts/pomerium/templates/authorize-deployment.yaml
@@ -70,6 +70,7 @@ spec:
             secretKeyRef:
               name: {{ template "pomerium.signingKeySecret.name" . }}
               key: signing-key
+{{  include "pomerium.sharedEnv" . | indent 8 }}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}
           value: {{ quote $value }}

--- a/charts/pomerium/templates/cache-deployment.yaml
+++ b/charts/pomerium/templates/cache-deployment.yaml
@@ -61,7 +61,8 @@ spec:
         env:
         - name: SERVICES
           value: cache
-{{- include "pomerium.databroker.tlsEnv" . | indent 8 }}
+{{  include "pomerium.databroker.storage.env" . | indent 8 }}
+{{- include "pomerium.sharedEnv" . | indent 8 }}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}
           value: {{ quote $value }}

--- a/charts/pomerium/templates/proxy-deployment.yaml
+++ b/charts/pomerium/templates/proxy-deployment.yaml
@@ -65,6 +65,7 @@ spec:
         env:
         - name: SERVICES
           value: proxy
+{{  include "pomerium.sharedEnv" . | indent 8 }}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}
           value: {{ quote $value }}

--- a/charts/pomerium/templates/redis/password-secret.yaml
+++ b/charts/pomerium/templates/redis/password-secret.yaml
@@ -1,9 +1,0 @@
-{{- if .Values.redis.enabled -}}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Values.redis.existingSecret }}
-type: Opaque
-data:
-  password: {{ include "pomerium.redis.password" . | b64enc }}
-{{- end -}}

--- a/charts/pomerium/templates/shared-secrets-and-derivatives.yaml
+++ b/charts/pomerium/templates/shared-secrets-and-derivatives.yaml
@@ -1,0 +1,86 @@
+{{- $shouldLookupExistingSecrets := and .Values.config.lookupExistingSecrets (not .Values.config.forceGenerateSharedSecrets) -}}
+{{- $existingSharedSecrets := and $shouldLookupExistingSecrets (lookup "v1" "Secret" .Release.Namespace (include "pomerium.sharedSecrets.name" . )) -}}
+{{- $existingSharedSecretData := or $existingSharedSecrets.data (dict) -}}
+{{- $existing_shared_secret := and $existingSharedSecretData.SHARED_SECRET ((or $existingSharedSecretData.SHARED_SECRET "") | b64dec) -}}
+{{- $existing_cookie_secret := and $existingSharedSecretData.COOKIE_SECRET ((or $existingSharedSecretData.COOKIE_SECRET "") | b64dec) -}}
+{{- $shared_secret := coalesce .Values.config.sharedSecret $existing_shared_secret (randAscii 32 | b64enc) -}}
+{{- $cookie_secret := coalesce .Values.config.cookieSecret $existing_cookie_secret (randAscii 32 | b64enc) -}}
+
+{{- $existingRedisSecret := and $shouldLookupExistingSecrets (lookup "v1" "Secret" .Release.Namespace .Values.redis.existingSecret) -}}
+{{- $existingRedisPassword := and $existingRedisSecret ((or (index (or $existingRedisSecret.data (dict)) .Values.redis.existingSecretPasswordKey) "") | b64dec) -}}
+{{- $redisPassword := coalesce .Values.redis.password $existingRedisPassword ($shared_secret | sha256sum) -}}
+
+{{/* Render redis scheme */}}
+{{- define "pomerium.redis.scheme" -}}
+{{- if .Values.redis.tls.enabled -}}
+rediss
+{{- else -}}
+redis
+{{- end -}}
+{{- end -}}
+
+{{- $redisConnectionString := printf "%s://:%s@%s-master.%s.svc.cluster.local:6379" (include "pomerium.redis.scheme" . ) $redisPassword (include "pomerium.redis.name" . ) .Release.Namespace -}}
+{{- $databrokerStorageConnectionString := default (and (eq (include "pomerium.databroker.storage.type" . ) "redis") $redisConnectionString) .Values.databroker.storage.connectionString -}}
+
+{{- $generatingSharedSecrets := and .Values.config.generateSharedSecrets (or .Release.IsInstall .Values.config.forceGenerateSharedSecrets) -}}
+{{- $defineSharedSecrets := or $generatingSharedSecrets .Values.config.sharedSecret .Values.config.cookieSecret -}}
+
+{{- if $defineSharedSecrets -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ template "pomerium.name" . }}
+    helm.sh/chart: {{ template "pomerium.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    helm.sh/hook-delete-policy: before-hook-creation
+{{- if .Values.config.forceGenerateSharedSecrets }}
+    helm.sh/hook: pre-upgrade
+{{- else if .Values.config.generateSharedSecrets }}
+    helm.sh/hook: pre-install
+{{- end }}
+  name: {{ template "pomerium.sharedSecrets.name" . }}
+type: Opaque
+data:
+{{- if or .Values.config.generateSharedSecrets .Values.config.sharedSecret }}
+  SHARED_SECRET: {{ $shared_secret | b64enc | quote }}
+{{- end }}
+{{- if or .Values.config.generateSharedSecrets .Values.config.cookieSecret }}
+  COOKIE_SECRET: {{ $cookie_secret | b64enc | quote }}
+{{- end }}
+{{- end }}
+{{ if and .Values.databroker.storage.autoconfigure (ne (include "pomerium.databroker.storage.type" . ) "memory") }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ template "pomerium.name" . }}
+    helm.sh/chart: {{ template "pomerium.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    helm.sh/hook-delete-policy: before-hook-creation
+{{- if .Values.config.forceGenerateSharedSecrets }}
+    helm.sh/hook: pre-upgrade
+{{- else if .Values.config.generateSharedSecrets }}
+    helm.sh/hook: pre-install
+{{- end }}
+  name: {{ template "pomerium.databroker.storage.secret.name" . }}
+type: Opaque
+data:
+  DATABROKER_STORAGE_CONNECTION_STRING: {{ $databrokerStorageConnectionString | b64enc | quote }}
+  DATABROKER_STORAGE_TLS_SKIP_VERIFY: {{ .Values.databroker.storage.tlsSkipVerify | toString | b64enc | quote }}
+{{- end }}
+{{ if .Values.redis.enabled -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.redis.existingSecret }}
+type: Opaque
+data:
+  password: {{ $redisPassword | b64enc | quote }}
+{{ end -}}

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -8,6 +8,8 @@ fullnameOverride: ""
 config:
   # routes under this wildcard domain are handled by pomerium
   rootDomain: corp.beyondperimeter.com
+
+  # secret value initialization
   existingSecret: ""
   existingCASecret: ""
   ca:
@@ -15,11 +17,15 @@ config:
     key: ""
   sharedSecret: ""
   cookieSecret: ""
+  generateSharedSecrets: true
+  lookupExistingSecrets: true
+  forceGenerateSharedSecrets: false
   generateTLS: true
   generateTLSAnnotations: {}
   forceGenerateTLS: false
   generateSigningKey: true
   forceGenerateSigningKey: false
+
   extraOpts: {}
   existingPolicy: ""
   insecure: false
@@ -119,6 +125,7 @@ cache:
 databroker:
   storage:
     type: "memory"
+    autoconfigure: true
     connectionString: ""
     tlsSkipVerify: false
     clientTLS:


### PR DESCRIPTION
## Summary

As described in https://github.com/pomerium/pomerium-helm/pull/168#issuecomment-714837290, this uses the same conditional-generation conditions that the chart uses for TLS certificates to generate the shared secret and cookie secret, as well as reading the values back from the cluster on subsequent upgrades.

It does this, with significant refactoring to declare variables within the same file instead of in outside templates (as described in https://github.com/helm/helm/issues/6456), so that other secrets (such as the Redis password) may be derived from the auto-generated secret.

Note that I've tested this as far as making sure the templates render and validate, whether `redis.enabled` is true or false, but I haven't actually tested it out on my cluster.

## Related issues

#167, #168

**Checklist**:
- [x] add related issues
- [x] update Configuration in README
- [x] update Changelog in README (major versions)
- [x] update Upgrading in README (breaking changes)
- [x] ready for review
