### PR TITLE
Switch ingress to ingress-nginx

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
           version: v3.3.1
 
       - name: "Add stable repo"
-        run: "helm repo add stable https://kubernetes-charts.storage.googleapis.com"
+        run: "helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx"
 
       - name: Run chart-testing (lint)
         id: lint
@@ -33,7 +33,7 @@ jobs:
           install_local_path_provisioner: true
 
       - name: Install Ingress Controller
-        run: "helm install stable/nginx-ingress --generate-name --set controller.service.type='NodePort'"
+        run: "helm install ingress-nginx/ingress-nginx --generate-name --set controller.service.type='NodePort'"
 
       - name: Run chart-testing (install)
         uses: helm/chart-testing-action@v1.0.0


### PR DESCRIPTION
## Summary
Switch CI ingress controller to ingress-nginx

NB: helm2 change detection isn't handling this correctly, but this should not trigger chart releaser.


**Checklist**:
- [x] ready for review
