### PR TITLE
set proper ingress api version

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 13.1.1
+version: 13.1.2
 appVersion: 0.10.6
 home: http://www.pomerium.io/
 icon: https://www.pomerium.com/img/logo-round.png

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -592,3 +592,14 @@ true
 {{- end }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pomerium/templates/ingress.yaml
+++ b/charts/pomerium/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "pomerium.fullname" . }}


### PR DESCRIPTION
## Summary
This PR fixes an issue with the deprecated ingress object in k8s 1.18.

```
Error: malformed chart or values: 
        templates/ingress.yaml: the kind "extensions/v1beta1 Ingress" is deprecated in favor of "networking.k8s.io/v1beta1 Ingress"
```