### PR TITLE
prevent checksum churn with extraEnv secrets

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 14.0.0
+version: 14.1.0
 appVersion: 0.11.1
 home: http://www.pomerium.io/
 icon: https://www.pomerium.com/img/logo-round.png


### PR DESCRIPTION
## Summary
Prevent autogeneration (and thus checksum churn) of `shared_secret` and `cookie_secret` when they're being set by `extraEnv`.

## Related issues
n/a


**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [ ] ready for review
