### PR TITLE
bump pomerium to v0.12

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pomerium
-version: 14.0.0
-appVersion: 0.11.1
+version: 15.0.0
+appVersion: 0.12.1
 home: http://www.pomerium.io/
 icon: https://www.pomerium.com/img/logo-round.png
 description: Pomerium is an identity-aware access proxy.
@@ -17,6 +17,7 @@ keywords:
 - google
 - okta
 - azure
+- auth0
 sources:
 - https://github.com/pomerium/pomerium
 engine: gotpl

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -18,6 +18,7 @@
   - [Redis Subchart](#redis-subchart)
   - [Configuration](#configuration)
   - [Changelog](#changelog)
+    - [15.0.0](#1500)
     - [14.0.0](#1400)
     - [13.0.0](#1300)
     - [11.0.0](#1100)
@@ -367,6 +368,9 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 
 ## Changelog
+### 15.0.0
+
+- Update to Pomerium `v0.12`.  See [v0.12 Upgrade Notes](https://www.pomerium.com/docs/upgrading.html#since-0-11-0).
 
 ### 14.0.0
 

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -173,7 +173,7 @@ operator:
   replicaCount: 1
   image:
     repository: "pomerium/pomerium-operator"
-    tag: "v0.0.4"
+    tag: "v0.0.5"
   config:
     ingressClass: pomerium
     serviceClass: pomerium
@@ -268,7 +268,7 @@ imagePullSecrets: ""
 
 image:
   repository: "pomerium/pomerium"
-  tag: "v0.11.1"
+  tag: "v0.12.1"
   pullPolicy: "IfNotPresent"
 
 metrics:


### PR DESCRIPTION
## Summary
- update default pomerium image to v0.12
- update default pomerium-operator image to v0.0.5

## Related issues
n/a


**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [x] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [ ] ready for review
