### PR TITLE
make ingress tls hosts unique

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 15.0.0
+version: 15.0.1
 appVersion: 0.12.1
 home: http://www.pomerium.io/
 icon: https://www.pomerium.com/img/logo-round.png

--- a/charts/pomerium/templates/ingress.yaml
+++ b/charts/pomerium/templates/ingress.yaml
@@ -16,7 +16,7 @@ spec:
   tls:
     - secretName: {{ default .Values.ingress.secretName .Values.ingress.secret.name}}
       hosts:
-{{      include "pomerium.ingress.tls.hosts" . | indent 8 }}
+{{      include "pomerium.ingress.tls.hosts" . | uniq | indent 8 }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ . | quote }}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

## Summary
Make the hosts lists uniq in the Ingress, otherwise the user might end up with:
```yaml
  tls:
  - hosts:
    - authenticate.localhost.banzaicloud.io
    - one-eye.localhost.banzaicloud.io
    - one-eye.localhost.banzaicloud.io
    - one-eye.localhost.banzaicloud.io
    - one-eye.localhost.banzaicloud.io
    - one-eye.localhost.banzaicloud.io
```

## Related issues
<!-- For example...
Fixes #159 
-->


**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [x] ready for review
