### PR TITLE
Update to Pomerium v0.13

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pomerium
-version: 15.1.0
-appVersion: 0.12.1
+version: 16.0.0
+appVersion: 0.13.1
 home: http://www.pomerium.io/
 icon: https://www.pomerium.com/img/logo-round.png
 description: Pomerium is an identity-aware access proxy.

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -18,6 +18,7 @@
   - [Redis Subchart](#redis-subchart)
   - [Configuration](#configuration)
   - [Changelog](#changelog)
+    - [16.0.0](#1600)
     - [15.0.0](#1500)
     - [14.0.0](#1400)
     - [13.0.0](#1300)
@@ -232,8 +233,8 @@ A full listing of Pomerium's configuration variables can be found on the [config
 | `databroker.storage.tlsSkipVerify`                           | Disable TLS verfication of storage backend service                                                                                                                                                                                                                                                 | `false`                                                                     |
 | `extraEnv`                                                   | Set `env` variables on service pods                                                                                                                                                                                                                                                                | []                                                                          |
 | `extraEnvFrom`                                               | Sets `envFrom` on service pods.  Can be used to source ENV vars from existing secrets or configmaps.  [Reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envfromsource-v1-core)                                                                                      | []                                                                          |
-| `extraVolumes`                                               | Set volumes on service pods                                                                                                                                                                                                                                                                | []                                                                          |
-| `extraVolumeMounts`                                          | Set volumeMounts on service containers                                                                                                                                                                                                                                                          | []                                                                          |
+| `extraVolumes`                                               | Set volumes on service pods                                                                                                                                                                                                                                                                        | []                                                                          |
+| `extraVolumeMounts`                                          | Set volumeMounts on service containers                                                                                                                                                                                                                                                             | []                                                                          |
 | `apiProxy`                                                   | Kubernetes API Server proxy configuration options.  Supported in pomerium `v0.10+`                                                                                                                                                                                                                 |                                                                             |
 | `apiProxy.enabled`                                           | Create service account, RBAC and ingress rules to proxy to the kubernetes api server on this cluster                                                                                                                                                                                               | `false`                                                                     |
 | `apiProxy.ingress`                                           | When `apiProxy.enabled` is `true`, inject an entry into the pomerium ingress resource                                                                                                                                                                                                              | true                                                                        |
@@ -370,6 +371,10 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 
 ## Changelog
+### 16.0.0
+
+- Update to Pomerium `v0.13`.  See [v0.13 Upgrade Notes](https://www.pomerium.com/docs/upgrading.html#since-0-12-0).
+
 ### 15.0.0
 
 - Update to Pomerium `v0.12`.  See [v0.12 Upgrade Notes](https://www.pomerium.com/docs/upgrading.html#since-0-11-0).

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -269,7 +269,7 @@ imagePullSecrets: ""
 
 image:
   repository: "pomerium/pomerium"
-  tag: "v0.12.1"
+  tag: "v0.13.1"
   pullPolicy: "IfNotPresent"
 
 metrics:


### PR DESCRIPTION
## Summary

Upgrade the default image to v0.13. 

## Related issues
n/a


**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [x] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
