### PR TITLE
filter tcp routes from ingress enumeration

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pomerium
-version: 16.0.1
+version: 16.0.2
 appVersion: 0.13.2
 home: http://www.pomerium.io/
 icon: https://www.pomerium.com/img/logo-round.png

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -587,7 +587,9 @@ true
   {{ end }}
 {{- if not (or .Values.ingress.hosts .Values.forwardAuth.enabled) }}
 {{- range .Values.config.policy }}
+{{- if hasPrefix "http" .from }}
 - {{ .from | trimPrefix "https://" | trimPrefix "http://" | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- range .Values.ingress.hosts }}

--- a/charts/pomerium/templates/ingress.yaml
+++ b/charts/pomerium/templates/ingress.yaml
@@ -28,12 +28,14 @@ spec:
     {{- end }}
     {{- if not (or .Values.ingress.hosts .Values.forwardAuth.enabled) }}
     {{- range .Values.config.policy }}
+    {{- if hasPrefix "http" .from }}
     - host: {{ .from | trimPrefix "https://" | trimPrefix "http://" | quote }}
       http:
         paths:
           - backend:
               serviceName: {{ template "pomerium.proxy.fullname" $ }}
               servicePort: {{ template "pomerium.httpTrafficPort.name" $ }}
+    {{- end }}
     {{- end }}
     {{- end }}
     {{- if and (.Values.forwardAuth.enabled) (not .Values.forwardAuth.internal)}}


### PR DESCRIPTION
## Summary
By default we populate our Ingress record with information from the configured policy.  If there are TCP routes present, however, the syntax breaks.  

Since TCP routes are very unlikely to work through an ingress, it's probably best they don't show up in the Ingress resource at all.  This should prevent cert-manager, external-dns, etc from getting the wrong information.

## Related issues
Closes https://github.com/pomerium/pomerium/issues/1981

**Checklist**:
- [x] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [ ] ready for review
