### PR TITLE
bump pomerium to v0.13.4

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pomerium
-version: 16.0.3
-appVersion: 0.13.2
+version: 16.0.4
+appVersion: 0.13.4
 home: http://www.pomerium.io/
 icon: https://www.pomerium.com/img/logo-round.png
 description: Pomerium is an identity-aware access proxy.

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -272,7 +272,7 @@ imagePullSecrets: ""
 
 image:
   repository: "pomerium/pomerium"
-  tag: "v0.13.2"
+  tag: "v0.13.4"
   pullPolicy: "IfNotPresent"
 
 metrics:


### PR DESCRIPTION
## Summary
Update default image to Pomerium v0.13.4

## Related issues
https://github.com/pomerium/pomerium/pull/2047
https://github.com/pomerium/pomerium/pull/2046


**Checklist**:
- [x] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
