### PR TITLE
Add support for authenticate behind proxy service

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 19.0.0
+version: 19.1.0
 appVersion: 0.14.2
 home: http://www.pomerium.io/
 icon: https://www.pomerium.com/img/logo-round.png

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -18,6 +18,7 @@
   - [Redis Subchart](#redis-subchart)
   - [Configuration](#configuration)
   - [Changelog](#changelog)
+    - [19.1.0](#1910)
     - [19.0.0](#1900)
     - [18.0.0](#1800)
     - [17.0.0](#1700)
@@ -275,6 +276,7 @@ A full listing of Pomerium's configuration variables can be found on the [config
 | `authenticate.tls.cert`                                      | TLS certificate for authenticate service                                                                                                                                                                                                                                                           |                                                                             |
 | `authenticate.tls.key`                                       | TLS key for authenticate service                                                                                                                                                                                                                                                                   |                                                                             |
 | `authenticate.cacheServiceUrl`                               | The internally accesible url for the cache service.                                                                                                                                                                                                                                                | `https://{{cache.name}}.{{config.rootDomain}}`                              |
+| `authenticate.proxied`                                       | When `ingress.enabled` is false, add a `policy` entry for the authenticate service.  This allows the proxy service to route traffic for `authenticate` directly                                                                                                                                    | `true`                                                                      |
 | `proxy.nameOverride`                                         | Name of the proxy service.                                                                                                                                                                                                                                                                         | `proxy`                                                                     |
 | `proxy.fullnameOverride`                                     | Full name of the proxy service.                                                                                                                                                                                                                                                                    | `proxy`                                                                     |
 | `proxy.authenticateServiceUrl`                               | The externally accessible url for the authenticate service.                                                                                                                                                                                                                                        | `https://{{authenticate.name}}.{{config.rootDomain}}`                       |
@@ -383,6 +385,10 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 
 ## Changelog
+
+### 19.1.0
+
+- Configure a route for the authenticate service if ingress is disabled.  This allows users to route all pomerium related traffic through the Pomerium proxy service in Loadbalancer or NodePort configuration.
 
 ### 19.0.0
 

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -472,6 +472,12 @@ policy:
 {{-    else }}
 {{       tpl (toYaml .Values.config.policy) . | indent 2 }}
 {{-    end  }}
+{{- if and (not .Values.ingress.enabled) .Values.authenticate.proxied }}
+  - from: https://{{ include "pomerium.authenticate.hostname" . }}
+    to: {{ printf "%s://%s.%s.svc.cluster.local" (include "pomerium.httpTrafficPort.name" .) (include "pomerium.authenticate.name" .) .Release.Namespace }}
+    preserve_host_header: true
+    allow_public_unauthenticated_access: true
+{{- end }}
 {{- end }}
 {{- end -}}
 

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -34,6 +34,7 @@ authenticate:
   existingTLSSecret: ""
   redirectUrl: ""
   cacheServiceUrl: ""
+  proxied: true
   # see https://www.pomerium.io/docs/identity-providers.html
   idp:
     provider: google


### PR DESCRIPTION
## Summary

With v0.14, authenticate can be hosted behind the Pomerium proxy as an unauthenticated route.  This allows users who do not want or need an Ingress to run the proxy service behind an L4 load balancer, performing L7 routing to authenticate in the pomerium proxy itself.  Only the proxy service needs an externally routable IP in this configuration.

This PR adds support for automatically configuring a route for the authenticate service when `ingress.enabled` is `false`.

`proxy.service.type` should be set to `LoadBalancer ` or `NodePort` if using this feature.  

## Related issues
n/a


**Checklist**:
- [ ] add related issues
- [x] update Configuration in README
- [x] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
