### PR TITLE
Remove subPath from TLS volumeMount

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 20.1.0
+version: 21.0.0
 appVersion: 0.14.5
 home: http://www.pomerium.io/
 icon: https://www.pomerium.com/img/logo-round.png

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -18,6 +18,7 @@
   - [Redis Subchart](#redis-subchart)
   - [Configuration](#configuration)
   - [Changelog](#changelog)
+    - [21.0.0](#2100)
     - [20.0.0](#2000)
     - [19.1.0](#1910)
     - [19.0.0](#1900)
@@ -42,6 +43,7 @@
     - [3.0.0](#300)
     - [2.0.0](#200)
   - [Upgrading](#upgrading)
+    - [21.0.0](#2100-1)
     - [20.0.0](#2000-1)
     - [18.0.0](#1800-1)
     - [17.0.0](#1700-1)
@@ -390,6 +392,10 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 ## Changelog
 
+### 21.0.0
+
+- Removed `subPath` from TLS `volumeMount`.  This allows changes to the underlying secret to be seen without recreating the pod.  If you are using `config.existingSecret` and directly managing your own configuration secret, see [upgrade notes](#2100-1) for details.
+
 ### 20.0.0
 
 - Renamed all `cache` resources to `databroker`.  This keeps the terminology in the chart aligned with core Pomerium documentation.  See [upgrade notes](#2000-1) for details.  
@@ -491,6 +497,13 @@ A full listing of Pomerium's configuration variables can be found on the [config
   - You must run pomerium v0.3.0+ to support this feature correctly
 
 ## Upgrading
+
+### 21.0.0
+
+- Users of `config.existingSecret`:
+  - Change `certificate_file` to `/pomerium/tls/tls.crt`
+  - Change `certificate_key_file` to `/pomerium/tls/tls.key`
+  - Change `certificate_authority_file` to `/pomerium/ca/ca.crt`
 
 ### 20.0.0
 

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -416,9 +416,9 @@ grpc is used for insecure rather than http for istio compatibility
 address: ":{{ template "pomerium.trafficPort.number" . }}"
 grpc_address: ":{{ template "pomerium.trafficPort.number" . }}"
 {{- if not .Values.config.insecure }}
-certificate_file: "/pomerium/cert.pem"
-certificate_key_file: "/pomerium/privkey.pem"
-certificate_authority_file: "/pomerium/ca.pem"
+certificate_file: "/pomerium/tls/tls.crt"
+certificate_key_file: "/pomerium/tls/tls.key"
+certificate_authority_file: "/pomerium/ca/ca.crt"
 {{- if .Values.extraTLSSecrets }}
 certificates:
 {{-   range .Values.extraTLSSecrets }}
@@ -506,15 +506,10 @@ policy:
 {{- define "pomerium.volumeMounts" -}}
 - mountPath: /etc/pomerium/
   name: config
-- mountPath: /pomerium/cert.pem
+- mountPath: /pomerium/tls
   name: service-tls
-  subPath: tls.crt
-- mountPath: /pomerium/privkey.pem
-  name: service-tls
-  subPath: tls.key
-- mountPath: /pomerium/ca.pem
+- mountPath: /pomerium/ca
   name: ca-tls
-  subPath: ca.crt
 {{- range .Values.extraTLSSecrets }}
 - mountPath: {{include "pomerium.extraTLSSecret.path" . }}{{ . }}
   name: {{ . }}


### PR DESCRIPTION
## Summary

We've been using `subPath` to mount TLS related secrets but `subPath` files from a `volumeMount` [are not updated](https://kubernetes.io/docs/concepts/storage/volumes/#secret) if the underlying `ConfigMap` or `Secret` are updated. This prevents certificate updates (such as those from `cert-manager`) from being picked up.

This PR updates the way we mount the volumes and reference the files to not rely on `subPath`.  For most users it is an internal change, but it does break `config.existingSecret`, so I've marked it as a major bump.

## Related issues

fixes https://github.com/pomerium/pomerium/issues/2308

**Checklist**:
- [x] add related issues
- [ ] update Configuration in README
- [x] update Changelog in README (major versions)
- [x] update Upgrading in README (breaking changes)
- [x] ready for review
