### PR TITLE
exclude legacy pomerium-cache service from prometheus service discovery

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 21.0.1
+version: 21.1.1
 appVersion: 0.14.5
 home: http://www.pomerium.io/
 icon: https://www.pomerium.com/img/logo-round.png

--- a/charts/pomerium/templates/servicemonitor.yaml
+++ b/charts/pomerium/templates/servicemonitor.yaml
@@ -16,6 +16,12 @@ metadata:
 {{- end }}
 spec:
   selector:
+      # TODO remove when pomerium-cache service is removed
+      matchExpressions:
+        key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - pomerium-cache
     matchLabels:
       helm.sh/chart: {{ template "pomerium.chart" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
## Summary
Filter `pomerium-cache` service from prometheus service discovery.  As-is, it creates duplicate scrapes of the same target pods.

## Related issues

n/a


**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
