### PR TITLE
Adding labels to Pomerium config secret

### DIFF
--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -18,6 +18,7 @@
   - [Redis Subchart](#redis-subchart)
   - [Configuration](#configuration)
   - [Changelog](#changelog)
+    - [22.1.0](#2210)
     - [22.0.0](#2200)
     - [21.0.1](#2101)
     - [21.0.0](#2100)
@@ -235,6 +236,7 @@ A full listing of Pomerium's configuration variables can be found on the [config
 | `config.cookieSecret`                                        | Cookie secret is a 32 byte key used to encrypt user sessions.                                                                                                                                                                                                                                      | 32 [random ascii chars](http://masterminds.github.io/sprig/strings.html)    |
 | `config.policy`                                              | List of routes and their policies. Accepts template values or string templates.  [See more](https://www.pomerium.com/reference/#policy).                                                                                                                                                           |                                                                             |
 | `config.extraOpts`                                           | Options Dictionary appended to the config file. May contain any additional config value that doesn't have its dedicated helm value counterpart.                                                                                                                                                    | {}                                                                          |
+| `config.extraSecretLabels`                                   | Labels to be applied to the Pomerium config secret.                                                                                                                                                                                                                                                | {}                                                                          |
 | `databroker`                                                 | Databroker configuration options.  Supported in `v0.10+`                                                                                                                                                                                                                                           |                                                                             |
 | `databroker.clientTLS.ca`                                    | Base64 encoded CA certificate for verifying the storage backend                                                                                                                                                                                                                                    |                                                                             |
 | `databroker.clientTLS.cert`                                  | Base64 encoded TLS client certificate for connecting to the storage backend                                                                                                                                                                                                                        |                                                                             |
@@ -395,6 +397,10 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 
 ## Changelog
+
+### 22.1.0
+
+- Added `extraSecretLabels` option to configure additional labels to put on the Pomerium config secret.
 
 ### 22.0.0
 - Explictly update redis dependency to v14.x.x.  See [upgrade notes](#2200-1) for details.

--- a/charts/pomerium/templates/secret.yaml
+++ b/charts/pomerium/templates/secret.yaml
@@ -25,6 +25,11 @@ metadata:
     helm.sh/chart: {{ template "pomerium.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.config.extraSecretLabels }}
+    {{- range $key, $value := .Values.config.extraSecretLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+{{- end }}
 type: Opaque
 stringData:
   config.yaml: |

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -27,6 +27,7 @@ config:
   policy: []
   existingSigningKeySecret: ""
   signingKey: ""
+  extraSecretLabels: {}
 
 authenticate:
   fullnameOverride: ""


### PR DESCRIPTION
## Summary
<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->
While Pomerium's components (authenticate, authorize, proxy, databroker) can be easily discovered through label expressions, Pomerium's config secret is not.
The labels put on the secret is too generic, and using them:
```
app.kubernetes.io/instance=supertubes
app.kubernetes.io/managed-by=Helm
app.kubernetes.io/name=pomerium
helm.sh/chart=pomerium-21.1.1
```
would result in also these secrets:
```
antala@ANTALA-M-9CMU ~ % k get secrets -A -l app.kubernetes.io/instance=supertubes -l app.kubernetes.io/name=pomerium
NAMESPACE  NAME                                      TYPE     DATA   AGE
pomerium   pomerium-pomerium                         Opaque   1      22h
pomerium   pomerium-pomerium-databroker-client-tls   Opaque   3      25h
pomerium   pomerium-pomerium-signing-key             Opaque   1      22h
```

It would be nice to add custom labels on the secret generated by the Helm chart to find it more easily. Unfortunately the name of the secret can be varied based on various Helm values, so I'd prefer a label based solution.

## Related issues
No related issue.

**Checklist**:
- [x] add related issues
- [x] update Configuration in README
- [x] update Changelog in README (major versions)
- [x] ready for review
