### PR TITLE
telemetry: specify metrics address with podIP

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 22.1.0
+version: 22.2.0
 appVersion: 0.14.7
 home: http://www.pomerium.io/
 icon: https://www.pomerium.com/img/logo-round.png

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -453,9 +453,6 @@ administrators: {{ .Values.config.administrators | quote }}
 
 {{ toYaml .Values.config.extraOpts -}}
 {{- end -}}
-{{- if .Values.metrics.enabled }}
-metrics_address: ":{{ .Values.metrics.port }}"
-{{- end -}}
 {{- if .Values.tracing.enabled }}
 tracing_debug: {{ .Values.tracing.debug }}
 tracing_provider: {{ required "tracing_provider is required for tracing" .Values.tracing.provider }}
@@ -658,4 +655,18 @@ Return the hostname of the authenticate service
 {{/* Expand the extraTLSSecret file path */}}
 {{- define "pomerium.extraTLSSecret.path" }}
 {{- print "/etc/pomerium/tls/" }}
+{{- end }}
+
+{{/* Return metrics env var block */}}
+{{- define "pomerium.metrics.envVars" }}
+{{- if .Values.metrics.enabled }}
+- name: POD_IP
+  valueFrom: 
+    fieldRef: 
+      fieldPath: status.podIP
+- name: METRICS_PORT
+  value: "{{ .Values.metrics.port }}"
+- name: METRICS_ADDRESS
+  value: "$(POD_IP):$(METRICS_PORT)"
+{{- end }}
 {{- end }}

--- a/charts/pomerium/templates/authenticate-deployment.yaml
+++ b/charts/pomerium/templates/authenticate-deployment.yaml
@@ -68,6 +68,7 @@ spec:
             secretKeyRef:
               name: {{ template "pomerium.signingKeySecret.name" . }}
               key: signing-key
+{{- include "pomerium.metrics.envVars" . | indent 8}}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}
           value: {{ quote $value }}

--- a/charts/pomerium/templates/authorize-deployment.yaml
+++ b/charts/pomerium/templates/authorize-deployment.yaml
@@ -70,6 +70,7 @@ spec:
             secretKeyRef:
               name: {{ template "pomerium.signingKeySecret.name" . }}
               key: signing-key
+{{- include "pomerium.metrics.envVars" . | indent 8}}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}
           value: {{ quote $value }}

--- a/charts/pomerium/templates/databroker-deployment.yaml
+++ b/charts/pomerium/templates/databroker-deployment.yaml
@@ -61,6 +61,7 @@ spec:
         env:
         - name: SERVICES
           value: databroker
+{{- include "pomerium.metrics.envVars" . | indent 8}}
 {{- include "pomerium.databroker.tlsEnv" . | indent 8 }}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}

--- a/charts/pomerium/templates/proxy-deployment.yaml
+++ b/charts/pomerium/templates/proxy-deployment.yaml
@@ -65,6 +65,7 @@ spec:
         env:
         - name: SERVICES
           value: proxy
+{{- include "pomerium.metrics.envVars" . | indent 8}}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}
           value: {{ quote $value }}


### PR DESCRIPTION
## Summary
Update the way we build the `metrics_address` parameter to use `[podIP]:[metrics.port]` using environment variables:

```yaml
        - name: POD_IP
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        - name: METRICS_PORT
          value: "9090"
        - name: METRICS_ADDRESS
          value: $(POD_IP):$(METRICS_PORT)
```

## Related issues
n/a


**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
