### PR TITLE
ci: update helm/chart-testing-action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,9 +39,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Run chart-testing
+      - name: Setup chart-testing
         id: lint
-        uses: helm/chart-testing-action@v2.0.1
-        with:
-          command: lint
-          config: .ct-release.yaml
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: Chart linting
+        run: |
+          ct lint --config .ct-release.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,23 +20,22 @@ jobs:
       - name: "Add nginx ingress repo"
         run: "helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx"
 
-      - name: Run chart-testing (lint)
+      - name: Setup chart-testing
         id: lint
-        uses: helm/chart-testing-action@v2.0.1
-        with:
-          command: lint
-          config: .ct.yaml
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: Chart linting
+        run: |
+          ct lint --config .ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-alpha.3
+        uses: helm/kind-action@v1.2.0
         with:
           install_local_path_provisioner: true
 
       - name: Install Ingress Controller
         run: "helm install ingress-nginx/ingress-nginx --generate-name --set controller.service.type='NodePort' --set controller.admissionWebhooks.enabled=false"
 
-      - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v2.0.1
-        with:
-          command: install
-          config: .ct.yaml
+      - name: Chart install
+        run: |
+          ct install --config .ct.yaml

--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 22.0.0
+version: 22.1.0
 appVersion: 0.14.7
 home: http://www.pomerium.io/
 icon: https://www.pomerium.com/img/logo-round.png


### PR DESCRIPTION
## Summary

~~It looks like the current action fails silently.~~  The v2 of `chart-testing-action` just sets up chart-testing rather than executing it.  This PR updates us to the current version, explicitly runs `ct`, and manually bumps the last chart version.

## Related issues
n/a


**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
