### PR TITLE
Remove unnecessary quotation marks from static config

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 23.0.0
+version: 23.1.0
 appVersion: 0.14.7
 home: http://www.pomerium.io/
 icon: https://www.pomerium.com/img/logo-round.png

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -18,6 +18,7 @@
   - [Redis Subchart](#redis-subchart)
   - [Configuration](#configuration)
   - [Changelog](#changelog)
+    - [23.1.0](#2310)
     - [23.0.0](#2300)
     - [22.1.0](#2210)
     - [22.0.0](#2200)
@@ -400,6 +401,10 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 
 ## Changelog
+
+### 23.1.0
+
+- Removed unnecessary `"` (quotation mark) from the `address` and `grpc_address` config fields in the static config template.  
 
 ### 23.0.0
 - Rename `forwardAuth.nameOverride` for consistency

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -413,8 +413,8 @@ grpc is used for insecure rather than http for istio compatibility
 
 {{/*Creates static configuration yaml */}}
 {{- define "pomerium.config.static" -}}
-address: ":{{ template "pomerium.trafficPort.number" . }}"
-grpc_address: ":{{ template "pomerium.trafficPort.number" . }}"
+address: :{{ template "pomerium.trafficPort.number" . }}
+grpc_address: :{{ template "pomerium.trafficPort.number" . }}
 {{- if not .Values.config.insecure }}
 certificate_file: "/pomerium/tls/tls.crt"
 certificate_key_file: "/pomerium/tls/tls.key"


### PR DESCRIPTION
## Summary
The static part of the Pomerium config secret contains two config options the values of which is enclosed with quotation marks. Since they have leading `:` characters and not numbers, according to the YAML specification, the quotation marks are unnecessary.

Generally it shouldn't be an issue if we enclose a string value with quotation marks, but we have a Go-based automation that verifies the `checksum/secret` annotations (they indeed match the value of the secret). Consecutive `yaml.Unmarshal` and `yaml.Marhshal` calls on the secret remove that quotation mark (but leaves everything else as it is) - providing us with a different sha256sum. 

We'd kindly appreciate if you could accept this contribution, though it may only affect us and maybe the [pomerium-operator](https://github.com/pomerium/pomerium-operator).

## Related issues
None

**Checklist**:
- [x] add related issues
- [x] update Configuration in README
- [x] update Changelog in README (major versions)
- [x] ready for review