### PR TITLE
Bump Core and Enterprise versions

### DIFF
--- a/charts/pomerium-console/Chart.yaml
+++ b/charts/pomerium-console/Chart.yaml
@@ -15,15 +15,16 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 7.0.0
+version: 7.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.15.0
+appVersion: 0.15.3
 
 maintainers:
   - name: Pomerium Developers
     url: https://www.pomerium.com
 
 home: https://www.pomerium.com
+icon: https://www.pomerium.com/img/icon.svg

--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,33 +1,33 @@
 apiVersion: v2
 name: pomerium
-version: 23.2.0
-appVersion: 0.14.7
-home: http://www.pomerium.io/
-icon: https://www.pomerium.com/img/logo-round.png
+version: 24.0.0
+appVersion: 0.15.2
+home: http://www.pomerium.com/
+icon: https://www.pomerium.com/img/icon.svg
 description: Pomerium is an identity-aware access proxy.
 keywords:
-- proxy
-- access-proxy
-- reverse-proxy
-- sso
-- openid connect
-- oauth2
-- authorization
-- authentication
-- google
-- okta
-- azure
-- auth0
+  - proxy
+  - access-proxy
+  - reverse-proxy
+  - sso
+  - openid connect
+  - oauth2
+  - authorization
+  - authentication
+  - google
+  - okta
+  - azure
+  - auth0
 sources:
-- https://github.com/pomerium/pomerium
+  - https://github.com/pomerium/pomerium
 engine: gotpl
 dependencies:
-- name: redis
-  version: "~14"
-  repository: https://charts.bitnami.com/bitnami
-  condition: redis.enabled
+  - name: redis
+    version: '~14'
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
 
 maintainers:
-- name: desimone
-  email: bdd@pomerium.io
-- name: travisgroth
+  - name: desimone
+    email: bdd@pomerium.io
+  - name: travisgroth

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -18,6 +18,7 @@
   - [Redis Subchart](#redis-subchart)
   - [Configuration](#configuration)
   - [Changelog](#changelog)
+    - [24.0.0](#2400)
     - [23.2.0](#2320)
     - [23.1.0](#2310)
     - [23.0.0](#2300)
@@ -403,6 +404,9 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 
 ## Changelog
+
+### 24.0.0
+- Update default Pomerium to v0.15. See [v0.15 Upgrade Notes](https://www.pomerium.com/docs/upgrading.html#since-0-14-0).
 
 ### 23.2.0
 

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -280,7 +280,7 @@ imagePullSecrets: ""
 
 image:
   repository: "pomerium/pomerium"
-  tag: "v0.14.7"
+  tag: "v0.15.2"
   pullPolicy: "IfNotPresent"
 
 metrics:


### PR DESCRIPTION
## Summary
- Update Pomerium Core to v0.15.2
- Update Pomerium Console to v0.15.3
- Update branding and link domains

## Related issues
n/a


**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [x] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
