### PR TITLE
Update Pomerium images to v0.15.6

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pomerium
-version: 25.0.0
-appVersion: 0.15.3
+version: 25.1.0
+appVersion: 0.15.6
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg
 description: Pomerium is an identity-aware access proxy.

--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 25.1.0
+version: 25.0.1
 appVersion: 0.15.6
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -431,6 +431,10 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 ## Changelog
 
+### 25.1.0
+
+- Updated Pomerium images to v0.15.6 to mitigate [CVE-2021-41230](https://github.com/pomerium/pomerium/security/advisories/GHSA-j6wp-3859-vxfg).
+
 ### 25.0.0
 - `config.policy` has been renamed to `config.routes` to match preferred upstream syntax.
 - Pomerium Operator has been replaced with [Pomerium Ingress Controller](https://github.com/pomerium/ingress-controller).

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -431,7 +431,7 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 ## Changelog
 
-### 25.1.0
+### 25.0.1
 
 - Updated Pomerium images to v0.15.6 to mitigate [CVE-2021-41230](https://github.com/pomerium/pomerium/security/advisories/GHSA-j6wp-3859-vxfg).
 

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -302,7 +302,7 @@ imagePullSecrets: ""
 
 image:
   repository: "pomerium/pomerium"
-  tag: "v0.15.5"
+  tag: "v0.15.6"
   pullPolicy: "IfNotPresent"
 
 metrics:


### PR DESCRIPTION
## Summary
Updated tags of the Pomerium images to `v0.15.6` to incorporate the fix for [CVE-2021-41230](https://github.com/pomerium/pomerium/security/advisories/GHSA-j6wp-3859-vxfg).

## Related issues
The https://github.com/pomerium/pomerium/pull/2724 fix for the Pomerium helm chart

**Checklist**:
- [x] add related issues
- [x] update Configuration in README
- [x] update Changelog in README (major versions)
- [x] ready for review
