### PR TITLE
properly join namespace list for ingressController

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 25.0.3
+version: 25.0.4
 appVersion: 0.15.7
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg

--- a/charts/pomerium/templates/ingress-controller-deployment.yaml
+++ b/charts/pomerium/templates/ingress-controller-deployment.yaml
@@ -53,7 +53,7 @@ spec:
         args:
           - --name={{ .Values.ingressController.config.ingressClass }}
           {{ if .Values.ingressController.config.namespaces -}}
-          - --namespaces={{ .Values.ingressController.config.namespaces }}
+          - --namespaces={{ .Values.ingressController.config.namespaces | join "," }}
           {{ end -}}
           - --databroker-service-url={{ printf "%s://%s.%s.svc.cluster.local" (include "pomerium.httpTrafficPort.name" .) (include "pomerium.databroker.fullname" .) .Release.Namespace }}
           - --databroker-tls-ca-file=/pomerium/ca/ca.crt


### PR DESCRIPTION
## Summary
When passing the contents of `ingressController.config.namespaces` to the ingress controller, we currently render the command line argument incorrectly if there is more than one.

This PR runs the namespace list through join so that multiple namespaces are properly rendered.

## Related issues
Fixes https://github.com/pomerium/pomerium-helm/issues/223


**Checklist**:
- [x] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
