### PR TITLE
renovate: automatically bump chart version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "extends": ["config:base", ":gitSignOff"],
-  "schedule": ["before 3pm every Weekday"]
+  "schedule": ["before 3pm every Weekday"],
+  "bumpVersion": "patch"
 }


### PR DESCRIPTION
## Summary
Specify the `bumpVersion` option so the chart version is incremented automatically by renovate.

## Related issues
https://github.com/pomerium/pomerium-helm/pull/229


**Checklist**:
- [x] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
