### PR TITLE
Bump helm version to v26 (pomerium v0.16.0)

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pomerium
-version: 25.0.6
-appVersion: 0.15.8
+version: 26.0.0
+appVersion: 0.16.0
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg
 description: Pomerium is an identity-aware access proxy.

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -302,7 +302,7 @@ imagePullSecrets: ""
 
 image:
   repository: "pomerium/pomerium"
-  tag: "v0.15.8"
+  tag: "v0.16.0"
   pullPolicy: "IfNotPresent"
 
 metrics:


### PR DESCRIPTION
## Summary
<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues
<!-- For example...
Fixes #159 
-->


**Checklist**:
- [x] add related issues
- [x] update Configuration in README
- [x] update Changelog in README (major versions)
- [x] update Upgrading in README (breaking changes)
- [x] ready for review
