### PR TITLE
[pomerium] Use `pomerium.authenticate.fullname` for internal authenticate route

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 28.0.0
+version: 28.0.1
 appVersion: 0.16.1
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -491,7 +491,7 @@ routes:
 {{-   end }}
 {{- if and .Values.authenticate.proxied (not .Values.ingressController.enabled) }}
   - from: https://{{ include "pomerium.authenticate.hostname" . }}
-    to: {{ printf "%s://%s.%s.svc.cluster.local" (include "pomerium.httpTrafficPort.name" .) (include "pomerium.authenticate.name" .) .Release.Namespace }}
+    to: {{ printf "%s://%s.%s.svc.cluster.local" (include "pomerium.httpTrafficPort.name" .) (include "pomerium.authenticate.fullname" .) .Release.Namespace }}
     preserve_host_header: true
     allow_public_unauthenticated_access: true
     tls_server_name: {{ include "pomerium.authenticate.hostname" . }}


### PR DESCRIPTION
## Summary

If the pomerium chart is installed with a name other than `pomerium`, we don't currently build the internal URL to authenticate correctly.  This PR changes our logic to use the right template.

## Related issues

n/a


**Checklist**:
- [x] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
