### PR TITLE
Fix podAnnotations for deployments

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 29.0.1
+version: 29.0.2
 appVersion: 0.16.2
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg

--- a/charts/pomerium/templates/authenticate-deployment.yaml
+++ b/charts/pomerium/templates/authenticate-deployment.yaml
@@ -33,6 +33,9 @@ spec:
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
+{{- if .Values.authenticate.deployment.podAnnotations }}
+{{ toYaml .Values.authenticate.deployment.podAnnotations | indent 8 }}
+{{- end }}
       labels:
         app.kubernetes.io/name: {{ template "pomerium.authenticate.name" . }}
         helm.sh/chart: {{ template "pomerium.chart" . }}
@@ -40,9 +43,6 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
-{{- end }}
-{{- if .Values.authenticate.deployment.podAnnotations }}
-{{ toYaml .Values.authenticate.deployment.podAnnotations | indent 8 }}
 {{- end }}
     spec:
 {{- if .Values.priorityClassName }}

--- a/charts/pomerium/templates/authorize-deployment.yaml
+++ b/charts/pomerium/templates/authorize-deployment.yaml
@@ -35,6 +35,9 @@ spec:
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
+{{- if .Values.authorize.deployment.podAnnotations }}
+{{ toYaml .Values.authorize.deployment.podAnnotations | indent 8 }}
+{{- end }}
       labels:
         app.kubernetes.io/name: {{ template "pomerium.authorize.name" . }}
         helm.sh/chart: {{ template "pomerium.chart" . }}
@@ -42,9 +45,6 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
-{{- end }}
-{{- if .Values.authorize.deployment.podAnnotations }}
-{{ toYaml .Values.authorize.deployment.podAnnotations | indent 8 }}
 {{- end }}
     spec:
 {{- if .Values.priorityClassName }}

--- a/charts/pomerium/templates/databroker-deployment.yaml
+++ b/charts/pomerium/templates/databroker-deployment.yaml
@@ -31,6 +31,9 @@ spec:
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
+{{- if .Values.databroker.deployment.podAnnotations }}
+{{ toYaml .Values.databroker.deployment.podAnnotations | indent 8 }}
+{{- end }}
       labels:
         app.kubernetes.io/name: {{ template "pomerium.databroker.name" . }}
         helm.sh/chart: {{ template "pomerium.chart" . }}
@@ -38,9 +41,6 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
-{{- end }}
-{{- if .Values.databroker.deployment.podAnnotations }}
-{{ toYaml .Values.databroker.deployment.podAnnotations | indent 8 }}
 {{- end }}
     spec:
 {{- if .Values.priorityClassName }}

--- a/charts/pomerium/templates/ingress-controller-deployment.yaml
+++ b/charts/pomerium/templates/ingress-controller-deployment.yaml
@@ -34,6 +34,9 @@ spec:
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
+{{- if .Values.ingressController.deployment.podAnnotations }}
+{{ toYaml .Values.ingressController.deployment.podAnnotations | indent 8 }}
+{{- end }}
       labels:
         app.kubernetes.io/name: {{ template "pomerium.ingressController.name" . }}
         helm.sh/chart: {{ template "pomerium.chart" . }}


### PR DESCRIPTION
## Summary
In the current version, the podAnnotations are injected in the pod labels sections instead of the annotations.
Furthermore, the ingressController deployment was missing the podAnnotations.

**Checklist**:
- [x] add related issues
- [x] update Configuration in README
- [x] update Changelog in README (major versions)
- [x] update Upgrading in README (breaking changes)
- [x] ready for review
