### PR TITLE
[pomerium] use authenticate_internal_service_url

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 30.0.1
+version: 30.1.0
 appVersion: 0.16.4
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg

--- a/charts/pomerium/templates/authenticate-deployment.yaml
+++ b/charts/pomerium/templates/authenticate-deployment.yaml
@@ -72,6 +72,8 @@ spec:
             secretKeyRef:
               name: {{ template "pomerium.signingKeySecret.name" . }}
               key: signing-key
+        - name: AUTHENTICATE_INTERNAL_SERVICE_URL
+          value: {{ (printf "%s://%s.%s.svc.cluster.local" (include "pomerium.httpTrafficPort.name" .) (include "pomerium.authenticate.fullname" .) .Release.Namespace ) }}
 {{- include "pomerium.metrics.envVars" . | indent 8}}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}

--- a/charts/pomerium/templates/authenticate-ingress.yaml
+++ b/charts/pomerium/templates/authenticate-ingress.yaml
@@ -9,9 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "pomerium.chart" . }}
   annotations:
-    ingress.pomerium.io/preserve_host_header: "true"
     ingress.pomerium.io/allow_public_unauthenticated_access: "true"
-    ingress.pomerium.io/tls_server_name: {{ include "pomerium.authenticate.hostname" . }}
 {{- if not .Values.config.insecure }}
     ingress.pomerium.io/secure_upstream: "true"
 {{- end }}


### PR DESCRIPTION
## Summary

Use the new `authenticate_internal_service_url` to configure `authenticate`'s internal hostname.  This removes the need for some workarounds in the authenticate `Ingress` record and some unintuitive behavior where `Ingress` TLS certificates can wind up being served by `authenticate`, breaking communication from the proxy.

This should be an internal-only change but it is substantial enough for a minor bump.

## Related issues
https://github.com/pomerium/pomerium/pull/2801

**Checklist**:
- [x] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
