### PR TITLE
fix: disable internal authenticate URL when using third party ingress

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 30.1.0
+version: 30.1.1
 appVersion: 0.16.4
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg

--- a/charts/pomerium/templates/authenticate-deployment.yaml
+++ b/charts/pomerium/templates/authenticate-deployment.yaml
@@ -72,8 +72,10 @@ spec:
             secretKeyRef:
               name: {{ template "pomerium.signingKeySecret.name" . }}
               key: signing-key
+{{- if not .Values.ingress.enabled }}
         - name: AUTHENTICATE_INTERNAL_SERVICE_URL
           value: {{ (printf "%s://%s.%s.svc.cluster.local" (include "pomerium.httpTrafficPort.name" .) (include "pomerium.authenticate.fullname" .) .Release.Namespace ) }}
+{{- end }}
 {{- include "pomerium.metrics.envVars" . | indent 8}}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}


### PR DESCRIPTION
## Summary

When using another ingress controller, we should continue using the external name for authenticate.

## Related issues
Closes #277 
Introduced in https://github.com/pomerium/pomerium-helm/pull/275


**Checklist**:
- [x] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
