### PR TITLE
[pomerium] fix: remove authenticate TLS workaround from non-ingress definition

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 30.1.1
+version: 30.1.2
 appVersion: 0.16.4
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg

--- a/charts/pomerium/templates/_helpers.tpl
+++ b/charts/pomerium/templates/_helpers.tpl
@@ -492,9 +492,7 @@ routes:
 {{- if and .Values.authenticate.proxied (not .Values.ingressController.enabled) }}
   - from: https://{{ include "pomerium.authenticate.hostname" . }}
     to: {{ printf "%s://%s.%s.svc.cluster.local" (include "pomerium.httpTrafficPort.name" .) (include "pomerium.authenticate.fullname" .) .Release.Namespace }}
-    preserve_host_header: true
     allow_public_unauthenticated_access: true
-    tls_server_name: {{ include "pomerium.authenticate.hostname" . }}
 {{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
## Summary
Remove the hostname override when the policy is explicitly configured.  

## Related issues
https://github.com/pomerium/pomerium-helm/pull/275

**Checklist**:
- [x] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
