### PR TITLE
allow omission of authenticate secret if a default cert is provided

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 31.0.1
+version: 31.0.2
 appVersion: 0.17.0
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg

--- a/charts/pomerium/templates/validation.yaml
+++ b/charts/pomerium/templates/validation.yaml
@@ -2,7 +2,9 @@
 {{ fail "`ingressController.enabled` is not compatible with `config.insecureProxy`" }}
 {{- end -}}
 {{- if and .Values.ingressController.enabled (not (or .Values.config.generateTLS .Values.authenticate.ingress.tls.secretName )) -}}
-{{ fail "A TLS certificate must be available for Authenticate when using the ingress controller.  Please set `config.generateTLS` or `authenticate.ingress.tls.secretName"}}
+{{- if not .Values.ingressController.ingressClassResource.defaultCertSecret -}}
+{{ fail "A TLS certificate must be available for Authenticate when using the ingress controller.  Please set `config.generateTLS`, `ingressController.ingressClassResource.defaultCertSecret` or `authenticate.ingress.tls.secretName"}}
+{{- end -}}
 {{- end -}}
 {{- if and (and .Values.ingressController.enabled (not .Values.ingressController.operatorMode)) .Values.ingress.enabled -}}
 {{ fail "`ingressController.enabled` is not compatible with `ingress.enabled` unless legacy `ingressController.operatorMode`" }}


### PR DESCRIPTION
## Summary
When using the new `ingressController.ingressClassResource.defaultCertSecret` setting, authenticate does not need an explicit cert for the ingress.

## Related issues
Fixes https://github.com/pomerium/pomerium-helm/issues/284


**Checklist**:
- [x] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
