### PR TITLE
ingress: Allow removal of the ingress TLS section

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 31.0.2
+version: 31.0.3
 appVersion: 0.17.0
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg

--- a/charts/pomerium/templates/ingress.yaml
+++ b/charts/pomerium/templates/ingress.yaml
@@ -22,10 +22,12 @@ spec:
   {{- end }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
+  {{ if  (or .Values.ingress.secret.name .Values.ingress.secretName) }}
   tls:
     - secretName: {{ default .Values.ingress.secret.name .Values.ingress.secretName }}
       hosts:
 {{      include "pomerium.ingress.tls.hosts" . | indent 8 }}
+  {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ . | quote }}


### PR DESCRIPTION
Allows disabling TLS if it's externally terminated (LB). Currently it's always defined, at least the hosts section.

https://github.com/pomerium/pomerium-helm/blob/main/charts/pomerium/templates/_helpers.tpl#L621-L641 (picks up ingress.hosts which I want defined).

LMK if it's any other way around it.

## Summary
<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues
<!-- For example...
Fixes #159 
-->


**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
