### PR TITLE
ci: set explicit token permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 on:
   push:
     branches:
@@ -6,6 +8,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: test
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: Chart Test
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## Summary

Adopt https://github.com/ossf/scorecard standards for default github token permissions.

## Related issues

https://github.com/pomerium/internal/issues/813

**Checklist**:
- [x] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
