### PR TITLE
disable ingress controller certificate check when insecureProxy = true

### DIFF
--- a/charts/pomerium-console/Chart.yaml
+++ b/charts/pomerium-console/Chart.yaml
@@ -20,7 +20,7 @@ version: 8.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.17.2
+appVersion: 0.17.0
 
 maintainers:
   - name: Pomerium Developers

--- a/charts/pomerium-console/Chart.yaml
+++ b/charts/pomerium-console/Chart.yaml
@@ -20,7 +20,7 @@ version: 8.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.17.0
+appVersion: 0.17.2
 
 maintainers:
   - name: Pomerium Developers

--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pomerium
 version: 31.1.4
-appVersion: 0.17.1
+appVersion: 0.17.2
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg
 description: Pomerium is an identity-aware access proxy.

--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 31.1.3
+version: 31.1.4
 appVersion: 0.17.1
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg
@@ -23,7 +23,7 @@ sources:
 engine: gotpl
 dependencies:
   - name: redis
-    version: '16.3.0'
+    version: "16.3.0"
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
 

--- a/charts/pomerium/templates/ingress-controller-deployment.yaml
+++ b/charts/pomerium/templates/ingress-controller-deployment.yaml
@@ -62,6 +62,9 @@ spec:
           - --databroker-tls-ca-file=/pomerium/ca/ca.crt
           - --metrics-bind-address=:8080
           - --health-probe-bind-address=:8081
+          {{- if (include "pomerium.proxy.insecure" .) -}}
+          - --disable-cert-check
+          {{- end -}}
           {{- if and .Values.ingressController.config.updateStatus (not .Values.ingressController.config.operatorMode) }}
           - --update-status-from-service={{ .Release.Namespace}}/{{ template "pomerium.proxy.fullname" . }}
           {{- end }}

--- a/charts/pomerium/templates/ingress-controller-deployment.yaml
+++ b/charts/pomerium/templates/ingress-controller-deployment.yaml
@@ -55,16 +55,16 @@ spec:
         imagePullPolicy: {{ .Values.ingressController.image.pullPolicy }}
         args:
           - --name={{ .Values.ingressController.config.ingressClass }}
-          {{ if .Values.ingressController.config.namespaces -}}
+          {{- if .Values.ingressController.config.namespaces }}
           - --namespaces={{ .Values.ingressController.config.namespaces | join "," }}
-          {{ end -}}
+          {{- end }}
           - --databroker-service-url={{ printf "%s://%s.%s.svc.cluster.local" (include "pomerium.httpTrafficPort.name" .) (include "pomerium.databroker.fullname" .) .Release.Namespace }}
           - --databroker-tls-ca-file=/pomerium/ca/ca.crt
           - --metrics-bind-address=:8080
           - --health-probe-bind-address=:8081
-          {{- if (include "pomerium.proxy.insecure" .) -}}
+          {{- if or .Values.config.insecure .Values.config.insecureProxy }}
           - --disable-cert-check
-          {{- end -}}
+          {{- end }}
           {{- if and .Values.ingressController.config.updateStatus (not .Values.ingressController.config.operatorMode) }}
           - --update-status-from-service={{ .Release.Namespace}}/{{ template "pomerium.proxy.fullname" . }}
           {{- end }}

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -202,7 +202,7 @@ ingressController:
   nameOverride: ""
   image:
     repository: "pomerium/ingress-controller"
-    tag: "v0.17.0"
+    tag: "v0.17.2"
   deployment:
     annotations: {}
     extraEnv: {}
@@ -305,7 +305,7 @@ imagePullSecrets: ""
 
 image:
   repository: "pomerium/pomerium"
-  tag: "v0.17.1"
+  tag: "v0.17.2"
   pullPolicy: "IfNotPresent"
 
 metrics:


### PR DESCRIPTION
## Summary

Disable TLS cert check for the ingress controller, if `insecureProxy=true`.

## Related issues

**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
