### PR TITLE
Fix invalid reference on ingress 'operatorMode' in validation.yaml

### DIFF
--- a/charts/pomerium/templates/validation.yaml
+++ b/charts/pomerium/templates/validation.yaml
@@ -1,4 +1,4 @@
-{{- if and (and .Values.ingressController.enabled (not .Values.ingressController.operatorMode)) .Values.config.insecureProxy -}}
+{{- if and (and .Values.ingressController.enabled (not .Values.ingressController.config.operatorMode)) .Values.config.insecureProxy -}}
 {{ fail "`ingressController.enabled` is not compatible with `config.insecureProxy`" }}
 {{- end -}}
 {{- if and .Values.ingressController.enabled (not (or .Values.config.generateTLS .Values.authenticate.ingress.tls.secretName )) -}}
@@ -6,6 +6,6 @@
 {{ fail "A TLS certificate must be available for Authenticate when using the ingress controller.  Please set `config.generateTLS`, `ingressController.ingressClassResource.defaultCertSecret` or `authenticate.ingress.tls.secretName"}}
 {{- end -}}
 {{- end -}}
-{{- if and (and .Values.ingressController.enabled (not .Values.ingressController.operatorMode)) .Values.ingress.enabled -}}
-{{ fail "`ingressController.enabled` is not compatible with `ingress.enabled` unless legacy `ingressController.operatorMode`" }}
+{{- if and (and .Values.ingressController.enabled (not .Values.ingressController.config.operatorMode)) .Values.ingress.enabled -}}
+{{ fail "`ingressController.enabled` is not compatible with `ingress.enabled` unless legacy `ingressController.config.operatorMode`" }}
 {{- end -}}


### PR DESCRIPTION
## Summary
This fixes the invalid reference to ingress `operatorMode` in `validation.yaml`.
The corrent reference to `operatorMode` should be `.Values.ingressController.config.operatorMode`.

**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
