### PR TITLE
add conditional to metrics port

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 32.0.4
+version: 32.0.5
 appVersion: v0.18.0
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg

--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 32.0.3
+version: 32.0.4
 appVersion: v0.18.0
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg

--- a/charts/pomerium/templates/proxy-service.yaml
+++ b/charts/pomerium/templates/proxy-service.yaml
@@ -49,10 +49,12 @@ spec:
       protocol: TCP
       port: 80
 {{- end }}
+{{- if .Values.metrics.enabled }}
     - name: metrics
       port: {{ .Values.metrics.port }}
       protocol: TCP
       targetPort: metrics
+{{- end }}
   selector:
     app.kubernetes.io/name: {{ template "pomerium.proxy.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
## Summary
When settings the variable metrics.enabled to false, the metrics are not exposed but the service port is still exposed.
It is not coherent and can be a security threat.

## Related issues
metrics port should not be exposed if the functionality is disabled #322: 
 https://github.com/pomerium/pomerium-helm/issues/322

**Checklist**:
- [x] add related issues
- [x] update Configuration in README --> no need,  metrics.enabled  already says -> Enable prometheus metrics endpoint
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
