### PR TITLE
add signing key

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 33.0.1
+version: 33.0.2
 appVersion: v0.20.0
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg
@@ -23,7 +23,7 @@ sources:
 engine: gotpl
 dependencies:
   - name: redis
-    version: '17.0.9'
+    version: "17.0.9"
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
 

--- a/charts/pomerium/templates/proxy-deployment.yaml
+++ b/charts/pomerium/templates/proxy-deployment.yaml
@@ -77,6 +77,11 @@ spec:
 {{- end }}
         - name: SERVICES
           value: proxy
+        - name: SIGNING_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "pomerium.signingKeySecret.name" . }}
+              key: signing-key
 {{- include "pomerium.metrics.envVars" . | indent 8}}
 {{- range $name, $value := .Values.extraEnv }}
         - name: {{ $name }}


### PR DESCRIPTION
## Summary
The signing key is required on the proxy service so the JWKS endpoint serves the right keys.

## Related issues
Fixes https://github.com/pomerium/internal/issues/1312

**Checklist**:
- [x] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
