### PR TITLE
upgrade to v0.22.2

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pomerium
-version: 33.0.2
-appVersion: v0.20.0
+version: 34.0.0
+appVersion: v0.22.0
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg
 description: Pomerium is an identity-aware access proxy.
@@ -23,7 +23,7 @@ sources:
 engine: gotpl
 dependencies:
   - name: redis
-    version: "17.0.9"
+    version: '17.0.9'
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
 

--- a/charts/pomerium/README.md
+++ b/charts/pomerium/README.md
@@ -462,11 +462,14 @@ A full listing of Pomerium's configuration variables can be found on the [config
 
 ## Changelog
 
+### 34.0.0
+
+- Upgrade to Pomerium Core v0.22.2, that addresses a critical security vulnerability [GHSA-pvrc-wvj2-f59p](https://github.com/pomerium/pomerium/security/advisories/GHSA-pvrc-wvj2-f59p)
+
 ### 33.0.0
 
 - `idp.serviceAccount` is removed. Please see the [Upgrade Guide](https://www.pomerium.com/docs/overview/upgrading#since-0200)
 - Update to v0.20.0 of Pomerium
-
 
 ### 32.0.0
 

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -203,7 +203,7 @@ ingressController:
   nameOverride: ''
   image:
     repository: 'pomerium/ingress-controller'
-    tag: 'sha-5623bd8'
+    tag: 'sha-54e3ddc'
     pullPolicy: IfNotPresent
   deployment:
     annotations: {}


### PR DESCRIPTION
- pin core to v0.22.2
- set ic to v0.22.2

## Summary
<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues
<!-- For example...
Fixes #159 
-->


**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [ ] ready for review
