### PR TITLE
feat: Support for hpa apiVersion autoscaling/v2

### DIFF
--- a/charts/pomerium/Chart.yaml
+++ b/charts/pomerium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pomerium
-version: 34.0.1
+version: 34.1.0
 appVersion: v0.22.0
 home: http://www.pomerium.com/
 icon: https://www.pomerium.com/img/icon.svg

--- a/charts/pomerium/templates/authenticate-hpa.yaml
+++ b/charts/pomerium/templates/authenticate-hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.authenticate.autoscaling.enabled }}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" -}}
+apiVersion: autoscaling/v2
+{{- else -}}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   labels:

--- a/charts/pomerium/templates/authorize-hpa.yaml
+++ b/charts/pomerium/templates/authorize-hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.authorize.autoscaling.enabled }}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" -}}
+apiVersion: autoscaling/v2
+{{- else -}}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   labels:

--- a/charts/pomerium/templates/proxy-hpa.yaml
+++ b/charts/pomerium/templates/proxy-hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.proxy.autoscaling.enabled }}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" -}}
+apiVersion: autoscaling/v2
+{{- else -}}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   labels:


### PR DESCRIPTION
## Summary
Since some managed kubernetes (e.g. GKE) stable channels are now on `v1.25`, api `autoscaling/v2beta1` is no longer served.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125

No issue opened so far, but will happen soon.

## Related issues
No issue open so far


**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [x] ready for review
