### PR TITLE
ingress controller pdb and replicas updated

### DIFF
--- a/charts/pomerium/templates/ingress-controller-deployment.yaml
+++ b/charts/pomerium/templates/ingress-controller-deployment.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   strategy:
     type: Recreate
-  replicas: 1
+  replicas: {{ include "pomerium.ingressController.replicaCount" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "pomerium.ingressController.name" . }}

--- a/charts/pomerium/templates/ingress-controller-pdb.yaml
+++ b/charts/pomerium/templates/ingress-controller-pdb.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ingressController.pdb.enabled -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+apiVersion: policy/v1
+{{- else -}}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ template "pomerium.ingressController.name" . }}
+    helm.sh/chart: {{ template "pomerium.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: ingressController
+  name: {{ template "pomerium.ingressController.fullname" . }}-pdp
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "pomerium.ingressController.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  minAvailable: {{ .Values.ingressController.pdb.minAvailable }}
+{{- end }}

--- a/charts/pomerium/values.yaml
+++ b/charts/pomerium/values.yaml
@@ -192,6 +192,7 @@ apiProxy:
 
 ingressController:
   enabled: false
+  replicaCount: 1
   ingressClassResource:
     enabled: true
     default: false
@@ -220,6 +221,9 @@ ingressController:
   service:
     annotations: {}
     type: ClusterIP
+  pdb:
+    enabled: false
+    minAvailable: 1
 
 forwardAuth:
   name: ''


### PR DESCRIPTION
## Summary

the ingress controller is hardcoded to have 1 replica and doesn't include a pdb

## Related issues

stops possible outage due to pod cycling 

**Checklist**:
- [ ] add related issues
- [ ] update Configuration in README
- [ ] update Changelog in README (major versions)
- [ ] update Upgrading in README (breaking changes)
- [ ] ready for review
